### PR TITLE
Cache gradle between docker builds, for speed

### DIFF
--- a/src/cordova/android/README.md
+++ b/src/cordova/android/README.md
@@ -39,6 +39,18 @@ A Docker image with all pre-requisites for Android builds is included. To build:
 - Install dependencies with `./tools/build/build.sh npm ci`
 - Then build with `./tools/build/build.sh npm run action gulp -- build android`
 
+### Cache gradle for faster builds
+
+If you are building often, to speed up your builds you can keep hold of the Gradle installation, so it won't be downloaded again each time. Simply export this variable before you call `build.sh` above:
+
+```bash
+export OUTLINE_BUILD_CACHE_GRADLE=1
+```
+
+This can reduce the build time by approximately 1 minute.
+
+> 💡 NOTE: This feature is not officially supported, so use it at your own risk! It is [not recommended](https://github.com/Jigsaw-Code/outline-client/pull/770#pullrequestreview-393337519) for CI/CD, or if you are changing Gradle's task inputs.
+
 ### To install the APK
 
 - Connect an Android device and enable [USB debugging](https://developer.android.com/studio/debug/dev-options.html#enable).

--- a/tools/build/build.sh
+++ b/tools/build/build.sh
@@ -50,9 +50,11 @@ fi
 
 if (( $# > 0 )); then
   readonly GIT_ROOT=$(git rev-parse --show-toplevel)
+  # To prevent every build from downloading a fresh copy of gradle, we can keep the downloaded gradle between builds and re-use it
+  readonly CACHE_GRADLE="-v /tmp/outline-docker-gradle-cache:/root/.gradle"
   # Rather than a working directory of something like "/worker", mirror
   # the path on the host so that symlink tricks work as expected.
-  docker run --rm -ti -v "$GIT_ROOT":"$GIT_ROOT" -w "$GIT_ROOT" -e SENTRY_DSN=${SENTRY_DSN:-} $IMAGE_NAME "$@"
+  docker run --rm -ti -v "$GIT_ROOT":"$GIT_ROOT" -w "$GIT_ROOT" -e SENTRY_DSN=${SENTRY_DSN:-} $CACHE_GRADLE $IMAGE_NAME "$@"
   # GNU stat uses -c for format, which BSD stat does not accept; it uses -f instead
   stat -c 2>&1 | grep -q illegal && STATFLAG="f" || STATFLAG="c"
   # TODO: Don't spin up a second container just to chown.

--- a/tools/build/build.sh
+++ b/tools/build/build.sh
@@ -51,7 +51,10 @@ fi
 if (( $# > 0 )); then
   readonly GIT_ROOT=$(git rev-parse --show-toplevel)
   # To prevent every build from downloading a fresh copy of gradle, we can keep the downloaded gradle between builds and re-use it
-  readonly CACHE_GRADLE="-v /tmp/outline-docker-gradle-cache:/root/.gradle"
+  CACHE_GRADLE=""
+  if [ -n "$OUTLINE_BUILD_CACHE_GRADLE" ]; then
+    CACHE_GRADLE="-v /tmp/outline-docker-gradle-cache:/root/.gradle"
+  fi
   # Rather than a working directory of something like "/worker", mirror
   # the path on the host so that symlink tricks work as expected.
   docker run --rm -ti -v "$GIT_ROOT":"$GIT_ROOT" -w "$GIT_ROOT" -e SENTRY_DSN=${SENTRY_DSN:-} $CACHE_GRADLE $IMAGE_NAME "$@"


### PR DESCRIPTION
When doing multiple builds in one day using Docker, it is noticeable that gradle is downloaded and installed from fresh for every build!

This impacts the build time (by over a minute here) and is somewhat antisocial to gradle servers.

This PR will persist the `/root/.gradle` folder in an external volume, so on subsequent builds there will be no need for the download and install step.

Notes:

- I chose to cache in `/tmp/xxx` because I figured most systems have that folder (Linux, macOS, Cygwin).

  But I would be happy to hear alternative suggestions. (As long as they don't use folders with a space in the name!)

----

### Alternative approach is probably worse

Initially I tried to get gradle pre-installed inside the image. That way everyone would have it from the start, and nobody would need to install it. However:

1. This was difficult to achieve. I failed to find a `gradle` command I could put into the `Dockerfile` to do this. (People on SO recommend doing a "light" build with a trimmed down build config...)

2. Doing this would **hard-code** a gradle version in the Dockerfile and the image.

   So probably _the approach in this PR is actually more future proof_. If the next release of cordova starts using a different version of gradle, it will probably just-work, with no need to update the image or change our code.