### PR TITLE
fix docker build for win32 ss-local

### DIFF
--- a/third_party/shadowsocks-libev/docker/mingw/Dockerfile
+++ b/third_party/shadowsocks-libev/docker/mingw/Dockerfile
@@ -18,7 +18,7 @@
 # <http://www.gnu.org/licenses/>.
 #
 
-FROM debian:testing
+FROM debian:buster
 
 ARG REPO=shadowsocks
 ARG REV=master


### PR DESCRIPTION
I used this docker image just now, and that cause a compile error as the debian team update there debian:test image frequently, the parent docker image should be a stable release.