### PR TITLE
[DRAFT] Try new multi-platform approach

### DIFF
--- a/src/types/outline.d.ts
+++ b/src/types/outline.d.ts
@@ -12,18 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// <reference path='../../types/outline.d.ts'/>
-
-import {Clipboard} from './clipboard_common';
-import {CordovaClipboard} from './clipboard_cordova';
-import {ElectronClipboard} from './clipboard_electron';
-
-export function getClipboard(): Clipboard {
-  if (outline.WEB_PLATFORM === 'cordova') {
-    return new CordovaClipboard();
-  } else if (outline.WEB_PLATFORM === 'electron') {
-    return new ElectronClipboard();
-  } else {
-    throw new Error('getClipboard() not implemented for platform');
-  }
+declare module outline {
+  const WEB_PLATFORM: 'cordova'|'electron';
 }

--- a/src/www/app/app.ts
+++ b/src/www/app/app.ts
@@ -16,7 +16,7 @@ import * as errors from '../model/errors';
 import * as events from '../model/events';
 import {Server} from '../model/server';
 
-import {Clipboard} from './clipboard';
+import {Clipboard} from './clipboard_common';
 import {EnvironmentVariables} from './environment';
 import {OutlineErrorReporter} from './error_reporter';
 import {OutlineServer, OutlineServerRepository} from './outline_server';

--- a/src/www/app/clipboard_common.ts
+++ b/src/www/app/clipboard_common.ts
@@ -36,7 +36,7 @@ export class AbstractClipboard implements Clipboard {
     this.listener = listener;
   }
 
-  emitEvent() {
+  protected emitEvent() {
     if (this.listener) {
       this.getContents().then(this.listener);
     }

--- a/src/www/app/clipboard_common.ts
+++ b/src/www/app/clipboard_common.ts
@@ -1,0 +1,44 @@
+// Copyright 2018 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export type ClipboardListener = (text: string) => void;
+
+export interface Clipboard {
+  // Returns the current contents of the clipboard.
+  getContents(): Promise<string>;
+
+  // Sets a callback to be invoked when the contents of the clipboard should be read. When this
+  // happens is implementation-dependent, e.g. it could be timer-based or, as is the case on mobile,
+  // whenever the app is brought to the foreground.
+  setListener(listener: ClipboardListener): void;
+}
+
+// Generic clipboard. Implementations should only have to implement getContents().
+export class AbstractClipboard implements Clipboard {
+  private listener: ClipboardListener|null = null;
+
+  getContents(): Promise<string> {
+    return Promise.reject(new Error('unimplemented skeleton method'));
+  }
+
+  setListener(listener: ClipboardListener) {
+    this.listener = listener;
+  }
+
+  emitEvent() {
+    if (this.listener) {
+      this.getContents().then(this.listener);
+    }
+  }
+}

--- a/src/www/app/clipboard_cordova.ts
+++ b/src/www/app/clipboard_cordova.ts
@@ -12,18 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// <reference path='../../types/outline.d.ts'/>
+/// <reference path='../../types/ambient/clipboard.d.ts'/>
 
-import {Clipboard} from './clipboard_common';
-import {CordovaClipboard} from './clipboard_cordova';
-import {ElectronClipboard} from './clipboard_electron';
+import {AbstractClipboard} from './clipboard_common';
 
-export function getClipboard(): Clipboard {
-  if (outline.WEB_PLATFORM === 'cordova') {
-    return new CordovaClipboard();
-  } else if (outline.WEB_PLATFORM === 'electron') {
-    return new ElectronClipboard();
-  } else {
-    throw new Error('getClipboard() not implemented for platform');
+// Pushes a clipboard event whenever the app is brought to the foreground.
+export class CordovaClipboard extends AbstractClipboard {
+  constructor() {
+    super();
+    document.addEventListener('resume', this.emitEvent.bind(this));
+  }
+
+  getContents() {
+    return new Promise<string>((resolve, reject) => {
+      cordova.plugins.clipboard.paste(resolve, reject);
+    });
   }
 }

--- a/src/www/app/clipboard_electron.ts
+++ b/src/www/app/clipboard_electron.ts
@@ -12,18 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// <reference path='../../types/outline.d.ts'/>
+import {clipboard, ipcRenderer} from 'electron';
 
-import {Clipboard} from './clipboard_common';
-import {CordovaClipboard} from './clipboard_cordova';
-import {ElectronClipboard} from './clipboard_electron';
+import {AbstractClipboard} from './clipboard_common';
 
-export function getClipboard(): Clipboard {
-  if (outline.WEB_PLATFORM === 'cordova') {
-    return new CordovaClipboard();
-  } else if (outline.WEB_PLATFORM === 'electron') {
-    return new ElectronClipboard();
-  } else {
-    throw new Error('getClipboard() not implemented for platform');
+// Pushes a clipboard event whenever the app window receives focus.
+export class ElectronClipboard extends AbstractClipboard {
+  constructor() {
+    super();
+    ipcRenderer.on('push-clipboard', this.emitEvent.bind(this));
+  }
+
+  getContents() {
+    return Promise.resolve(clipboard.readText());
   }
 }

--- a/src/www/app/cordova_main.ts
+++ b/src/www/app/cordova_main.ts
@@ -24,7 +24,6 @@ setRootPath(location.pathname.substring(0, location.pathname.lastIndexOf('/') + 
 
 import * as sentry from '@sentry/browser';
 
-import {AbstractClipboard} from './clipboard';
 import {EnvironmentVariables} from './environment';
 import {SentryErrorReporter} from './error_reporter';
 import {FakeNativeNetworking} from './fake_net';
@@ -39,21 +38,6 @@ import {FakeOutlineTunnel} from './fake_tunnel';
 import {ShadowsocksConfig} from './config';
 
 const OUTLINE_PLUGIN_NAME = 'OutlinePlugin';
-
-
-// Pushes a clipboard event whenever the app is brought to the foreground.
-class CordovaClipboard extends AbstractClipboard {
-  constructor() {
-    super();
-    document.addEventListener('resume', this.emitEvent.bind(this));
-  }
-
-  getContents() {
-    return new Promise<string>((resolve, reject) => {
-      cordova.plugins.clipboard.paste(resolve, reject);
-    });
-  }
-}
 
 // Helper function to call the Outline Cordova plugin.
 function pluginExec<T>(cmd: string, ...args: unknown[]): Promise<T> {
@@ -149,10 +133,6 @@ class CordovaPlatform implements OutlinePlatform {
     }
     console.warn('no intent interceptor available');
     return new interceptors.UrlInterceptor();
-  }
-
-  getClipboard() {
-    return new CordovaClipboard();
   }
 
   getErrorReporter(env: EnvironmentVariables) {

--- a/src/www/app/electron_main.ts
+++ b/src/www/app/electron_main.ts
@@ -16,11 +16,10 @@ import 'web-animations-js/web-animations-next-lite.min.js';
 import '@webcomponents/webcomponentsjs/webcomponents-bundle.js';
 
 import * as sentry from '@sentry/electron';
-import {clipboard, ipcRenderer} from 'electron';
+import {ipcRenderer} from 'electron';
 import * as promiseIpc from 'electron-promise-ipc';
 import * as os from 'os';
 
-import {AbstractClipboard} from './clipboard';
 import {ElectronOutlineTunnel} from './electron_outline_tunnel';
 import {EnvironmentVariables} from './environment';
 import {getSentryBrowserIntegrations, OutlineErrorReporter} from './error_reporter';
@@ -53,18 +52,6 @@ ipcRenderer.on('localizationRequest', (e: Event, localizationKeys: string[]) => 
   }
   ipcRenderer.send('localizationResponse', localizationResult);
 });
-
-// Pushes a clipboard event whenever the app window receives focus.
-class ElectronClipboard extends AbstractClipboard {
-  constructor() {
-    super();
-    ipcRenderer.on('push-clipboard', this.emitEvent.bind(this));
-  }
-
-  getContents() {
-    return Promise.resolve(clipboard.readText());
-  }
-}
 
 class ElectronUpdater extends AbstractUpdater {
   constructor() {
@@ -112,9 +99,6 @@ main({
   },
   getUrlInterceptor: () => {
     return interceptor;
-  },
-  getClipboard: () => {
-    return new ElectronClipboard();
   },
   getErrorReporter: (env: EnvironmentVariables) => {
     // Initialise error reporting in the main process.

--- a/src/www/app/main.ts
+++ b/src/www/app/main.ts
@@ -17,6 +17,7 @@ import '../ui_components/app-root.js';
 import {EventQueue} from '../model/events';
 
 import {App} from './app';
+import * as clipboard from './clipboard';
 import {onceEnvVars} from './environment';
 import {NativeNetworking} from './net';
 import {OutlineServerRepository, shadowsocksConfigToAccessKey} from './outline_server';
@@ -93,7 +94,7 @@ export function main(platform: OutlinePlatform) {
             const settings = new Settings();
             const app = new App(
                 eventQueue, serverRepo, getRootEl(), debugMode, platform.getUrlInterceptor(),
-                platform.getClipboard(), platform.getErrorReporter(environmentVars), settings,
+                clipboard.getClipboard(), platform.getErrorReporter(environmentVars), settings,
                 environmentVars, platform.getUpdater(), platform.quitApplication);
           },
           (e) => {

--- a/src/www/app/platform.ts
+++ b/src/www/app/platform.ts
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Clipboard} from './clipboard';
 import {EnvironmentVariables} from './environment';
 import {OutlineErrorReporter} from './error_reporter';
 import {NativeNetworking} from './net';
@@ -34,8 +33,6 @@ export interface OutlinePlatform {
   getTunnelFactory(): TunnelFactory;
 
   getUrlInterceptor(): UrlInterceptor|undefined;
-
-  getClipboard(): Clipboard;
 
   getErrorReporter(environment: EnvironmentVariables): OutlineErrorReporter;
 

--- a/src/www/webpack_base.js
+++ b/src/www/webpack_base.js
@@ -49,6 +49,7 @@ exports.makeConfig = (options) => {
       fallback: {'url': require.resolve('url/')},
     },
     optimization: {
+      usedExports: true,
       minimizer: [new TerserPlugin({
         terserOptions: {
           keep_classnames: true,

--- a/src/www/webpack_cordova.js
+++ b/src/www/webpack_cordova.js
@@ -66,6 +66,7 @@ module.exports = makeConfig({
       ],
       {context: __dirname}),
     new webpack.DefinePlugin({
+      'outline.WEB_PLATFORM': 'cordova',
       // Statically link the Roboto font, rather than link to fonts.googleapis.com
       'window.polymerSkipLoadingFontRoboto': JSON.stringify(true),
     }),

--- a/src/www/webpack_electron.js
+++ b/src/www/webpack_electron.js
@@ -46,6 +46,7 @@ module.exports = makeConfig({
   ],
   extraPlugins: [
     new webpack.DefinePlugin({
+      'outline.WEB_PLATFORM': 'cordova',
       // Hack to protect against @sentry/electron not having process.type defined.
       'process.type': JSON.stringify('renderer'),
       // Statically link the Roboto font, rather than link to fonts.googleapis.com

--- a/src/www/webpack_electron.js
+++ b/src/www/webpack_electron.js
@@ -46,7 +46,7 @@ module.exports = makeConfig({
   ],
   extraPlugins: [
     new webpack.DefinePlugin({
-      'outline.WEB_PLATFORM': 'cordova',
+      'outline.WEB_PLATFORM': 'electron',
       // Hack to protect against @sentry/electron not having process.type defined.
       'process.type': JSON.stringify('renderer'),
       // Statically link the Roboto font, rather than link to fonts.googleapis.com


### PR DESCRIPTION
This is an attempt to do multi-platform in a way that the caller doesn't need to know a library has different implementations based on the platform. It removes the need for a gigantic Platform class and simplifies the code.

I wanted an approach that makes the IDE happy, and this seems to accomplish that (versus renaming or generating files, for example).

I was hoping to have Webpack remove the unused code. However, it doesn't seem to be removing the Electron code when `outline.WEB_PLATFORM ===  'cordova'`.

Any ideas on how else I could do this?

I'm thinking of perhaps having `clipboard.ts` be a symlink to one of `clipboard_{cordova|electron}.ts`. The symlink could be created at build time. Perhaps we have some build code that whenever it sees files like .<platform>.ts is removes the platform suffix. But that would make the IDE unhappy. Or perhaps we have preprocessing marks in the files to remove/keep sections of it.


