### PR TITLE
chore(cordova/android): outline android lib

### DIFF
--- a/src/cordova/android/OutlineAndroidLib/build.gradle
+++ b/src/cordova/android/OutlineAndroidLib/build.gradle
@@ -2,4 +2,5 @@
 plugins {
     // This version number must be kept in sync with AGP_VERSION in cordova-android.
     id 'com.android.library' version '7.2.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.6.21' apply false
 }

--- a/src/cordova/android/OutlineAndroidLib/outline/build.gradle
+++ b/src/cordova/android/OutlineAndroidLib/outline/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'com.android.library'
+    id 'org.jetbrains.kotlin.android'
 }
 
 // Needed for the composite build to recognize this module as 'org.outline:outline:0.0'.

--- a/src/cordova/android/OutlineAndroidLib/outline/src/main/java/org/outline/vpn/VpnTunnelService.java
+++ b/src/cordova/android/OutlineAndroidLib/outline/src/main/java/org/outline/vpn/VpnTunnelService.java
@@ -352,6 +352,7 @@ public class VpnTunnelService extends VpnService {
   private void tearDownActiveTunnel() {
     stopVpnTunnel();
     stopForeground();
+    broadcastVpnConnectivityChange(TunnelStatus.DISCONNECTED);
     tunnelConfig = null;
     stopNetworkConnectivityMonitor();
     tunnelStore.setTunnelStatus(TunnelStatus.DISCONNECTED);


### PR DESCRIPTION
Modification for developing outline Android SDK by nthlink.

- Upgrade gradle version
- Support kotlin 1.8
- Upgrade compileSdk and targetSdk to 33
- Broadcast vpn status disconnected while tear down active tunnel.