### PR TITLE
fix(devtools): Changed FakeOutlineTunnel to check for ip and not tag

### DIFF
--- a/src/www/app/fake_tunnel.ts
+++ b/src/www/app/fake_tunnel.ts
@@ -24,12 +24,12 @@ export class FakeOutlineTunnel implements Tunnel {
 
   constructor(public readonly id: string) {}
 
-  private playBroken(hostname?: string) {
-    return hostname?.toLowerCase().includes('broken');
+  private playBroken(host?: string) {
+    return host?.includes('192.0.2.1');
   }
 
-  private playUnreachable(hostname?: string) {
-    return hostname?.toLowerCase().includes('unreachable');
+  private playUnreachable(host?: string) {
+    return host?.includes('10.0.0.24');
   }
 
   async start(config: ShadowsocksSessionConfig): Promise<void> {


### PR DESCRIPTION
Hello!

I was trying to launch project locally to play around and try to implement one of the features requested in the issues here.
I noticed that fake servers do not give any errors when I try to connect to them and looks like it's because host is used not instead of the tag. So I replaced tags with ips for the ease of work.

Hope it helps and I did not miss any bigger context.