### PR TITLE
fix(cordova/apple/macos): create new `NETunnelProviderManager` instances when moving to Catalyst

### DIFF
--- a/src/cordova/apple/OutlineAppleLib/Sources/OutlineTunnel/NETunnelProviderManager+Outline.swift
+++ b/src/cordova/apple/OutlineAppleLib/Sources/OutlineTunnel/NETunnelProviderManager+Outline.swift
@@ -15,7 +15,23 @@
 import Foundation
 import NetworkExtension
 
+public enum TunnelProviderKeys {
+  static let keyVersion = "version"
+}
+
 public extension NETunnelProviderManager {
+  // Checks if the configuration has gone stale, which means clients should discard it.
+  var isStale: Bool {
+    // When moving from macOS to Mac Catalyst, we need to delete the existing profile and create a new
+    // one. We track such "stale" profiles by a version on the provider configuration.
+    if let protocolConfiguration = protocolConfiguration as? NETunnelProviderProtocol {
+        var providerConfig: [String: Any] = protocolConfiguration.providerConfiguration ?? [:]
+        let version = providerConfig[TunnelProviderKeys.keyVersion, default: 0] as! Int
+        return version != 1
+    }
+    return true
+  }
+
   var autoConnect: Bool {
     get {
       let hasOnDemandRules = !(self.onDemandRules?.isEmpty ?? true)

--- a/src/cordova/apple/OutlineAppleLib/Sources/OutlineTunnel/NETunnelProviderManager+Outline.swift
+++ b/src/cordova/apple/OutlineAppleLib/Sources/OutlineTunnel/NETunnelProviderManager+Outline.swift
@@ -1,0 +1,35 @@
+// Copyright 2024 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import NetworkExtension
+
+public extension NETunnelProviderManager {
+  var autoConnect: Bool {
+    get {
+      let hasOnDemandRules = !(self.onDemandRules?.isEmpty ?? true)
+      return self.isEnabled && hasOnDemandRules
+    }
+    set {
+      if newValue {
+        let connectRule = NEOnDemandRuleConnect()
+        connectRule.interfaceTypeMatch = .any
+        self.onDemandRules = [connectRule]
+      } else {
+        self.onDemandRules = nil
+      }
+      self.isEnabled = newValue
+    }
+  }
+}

--- a/src/cordova/apple/OutlineAppleLib/Sources/OutlineTunnel/NETunnelProviderManager+Outline.swift
+++ b/src/cordova/apple/OutlineAppleLib/Sources/OutlineTunnel/NETunnelProviderManager+Outline.swift
@@ -22,14 +22,19 @@ public enum TunnelProviderKeys {
 public extension NETunnelProviderManager {
   // Checks if the configuration has gone stale, which means clients should discard it.
   var isStale: Bool {
-    // When moving from macOS to Mac Catalyst, we need to delete the existing profile and create a new
-    // one. We track such "stale" profiles by a version on the provider configuration.
-    if let protocolConfiguration = protocolConfiguration as? NETunnelProviderProtocol {
-        var providerConfig: [String: Any] = protocolConfiguration.providerConfiguration ?? [:]
-        let version = providerConfig[TunnelProviderKeys.keyVersion, default: 0] as! Int
-        return version != 1
-    }
-    return true
+    #if targetEnvironment(macCatalyst)
+      // When migrating from macOS to Mac Catalyst, we can't use managers created by the macOS app.
+      // Instead, we need to create a new one. We track such "stale" managers by a version on the
+      // provider configuration.
+      if let protocolConfiguration = protocolConfiguration as? NETunnelProviderProtocol {
+          var providerConfig: [String: Any] = protocolConfiguration.providerConfiguration ?? [:]
+          let version = providerConfig[TunnelProviderKeys.keyVersion, default: 0] as! Int
+          return version != 1
+      }
+      return true
+    #else
+     return false
+    #endif
   }
 
   var autoConnect: Bool {

--- a/src/cordova/apple/OutlineAppleLib/Sources/OutlineTunnel/OutlineVpn.swift
+++ b/src/cordova/apple/OutlineAppleLib/Sources/OutlineTunnel/OutlineVpn.swift
@@ -178,8 +178,7 @@ public class OutlineVpn: NSObject {
     getTunnelManager() { tunnelManager in
       var manager: NETunnelProviderManager!
       if let manager = tunnelManager {
-        let hasOnDemandRules = !(manager.onDemandRules?.isEmpty ?? true)
-        if manager.isEnabled && hasOnDemandRules {
+        if manager.autoConnect {
           self.tunnelManager = manager
           return completion(true)
         }
@@ -191,11 +190,7 @@ public class OutlineVpn: NSObject {
         manager = NETunnelProviderManager()
         manager.protocolConfiguration = config
       }
-      // Set an on-demand rule to connect to any available network to implement auto-connect on boot
-      let connectRule = NEOnDemandRuleConnect()
-      connectRule.interfaceTypeMatch = .any
-      manager.onDemandRules = [connectRule]
-      manager.isEnabled = true
+      manager.autoConnect = true
       manager.saveToPreferences() { error in
         if let error = error {
           DDLogError("Failed to save VPN configuration: \(error)")

--- a/src/cordova/apple/OutlineAppleLib/Sources/OutlineTunnel/OutlineVpn.swift
+++ b/src/cordova/apple/OutlineAppleLib/Sources/OutlineTunnel/OutlineVpn.swift
@@ -196,7 +196,7 @@ public class OutlineVpn: NSObject {
           DDLogError("Failed to save VPN configuration: \(error)")
           return completion(false)
         }
-        self.observeVpnStatusChange(manager!)
+        self.observeVpnStatusChange(manager)
         self.tunnelManager = manager
         NotificationCenter.default.post(name: .NEVPNConfigurationChange, object: nil)
         // Workaround for https://forums.developer.apple.com/thread/25928

--- a/src/cordova/apple/OutlineAppleLib/Sources/OutlineTunnel/OutlineVpn.swift
+++ b/src/cordova/apple/OutlineAppleLib/Sources/OutlineTunnel/OutlineVpn.swift
@@ -21,6 +21,7 @@ import Tun2socks
 public class OutlineVpn: NSObject {
   public static let shared = OutlineVpn()
   private static let kVpnExtensionBundleId = "\(Bundle.main.bundleIdentifier!).VpnExtension"
+  private static let kVpnServerAddress = "Outline"
 
   public typealias Callback = (ErrorCode) -> Void
   public typealias VpnStatusObserver = (NEVPNStatus, String) -> Void
@@ -175,38 +176,29 @@ public class OutlineVpn: NSObject {
   // Adds a VPN configuration to the user preferences if no Outline profile is present. Otherwise
   // enables the existing configuration.
   private func setupVpn(completion: @escaping(Bool) -> Void) {
-    getTunnelManager() { tunnelManager in
-      var manager: NETunnelProviderManager!
-      if let manager = tunnelManager {
-        if manager.autoConnect {
-          self.tunnelManager = manager
-          return completion(true)
-        }
-      } else {
-        let config = NETunnelProviderProtocol()
-        config.providerBundleIdentifier = OutlineVpn.kVpnExtensionBundleId
-        config.serverAddress = "Outline"
-
-        manager = NETunnelProviderManager()
-        manager.protocolConfiguration = config
+    getOrCreateTunnelManager() { manager in
+      guard let manager else {
+        DDLogError("Failed to setup tunnel manager")
+        return completion(false)
       }
-      manager.autoConnect = true
-      manager.saveToPreferences() { error in
-        if let error = error {
-          DDLogError("Failed to save VPN configuration: \(error)")
-          return completion(false)
-        }
-        self.observeVpnStatusChange(manager)
-        self.tunnelManager = manager
-        NotificationCenter.default.post(name: .NEVPNConfigurationChange, object: nil)
-        // Workaround for https://forums.developer.apple.com/thread/25928
-        self.tunnelManager?.loadFromPreferences() { error in
-          if let error = error {
-            DDLogError("Failed to get tunnel manage: \(error)")
-            return completion(false)
-          }
-          return completion(true)
-        }
+
+      guard manager.autoConnect else {
+        manager.autoConnect = true
+        return self.saveTunnelManager(manager, completion)
+      }
+
+      self.tunnelManager = manager
+      return completion(true)
+    }
+  }
+
+  private func getOrCreateTunnelManager(_ completion: @escaping ((NETunnelProviderManager?) -> Void)) {
+    getTunnelManager() { manager in
+      if let manager = manager {
+        return completion(manager)
+      }
+      self.createTunnelManager() { newManager in
+        return completion(newManager)
       }
     }
   }
@@ -220,6 +212,27 @@ public class OutlineVpn: NSObject {
     }
   }
 
+  // Creates the application's tunnel provider manager and saves it in the VPN preferences.
+  private func createTunnelManager(_ completion: @escaping ((NETunnelProviderManager?) -> Void)) {
+    let config = NETunnelProviderProtocol()
+    config.providerBundleIdentifier = OutlineVpn.kVpnExtensionBundleId
+    config.serverAddress = OutlineVpn.kVpnServerAddress
+    config.providerConfiguration = [TunnelProviderKeys.keyVersion: 1]
+
+    let manager = NETunnelProviderManager()
+    manager.protocolConfiguration = config
+    manager.autoConnect = true
+
+    self.saveTunnelManager(manager) { success in
+      guard success else {
+        DDLogError("Failed to create new tunnel manager")
+        return completion(nil)
+      }
+      DDLogInfo("Created new tunnel manager")
+      return completion(manager)
+    }
+  }
+
   // Retrieves the application's tunnel provider manager from the VPN preferences.
   private func getTunnelManager(_ completion: @escaping ((NETunnelProviderManager?) -> Void)) {
     NETunnelProviderManager.loadAllFromPreferences() { (managers, error) in
@@ -227,11 +240,42 @@ public class OutlineVpn: NSObject {
         completion(nil)
         return DDLogError("Failed to get tunnel manager: \(String(describing: error))")
       }
-      var manager: NETunnelProviderManager?
-      if managers!.count > 0 {
-        manager = managers!.first
+
+      DDLogInfo("Loaded \(managers!.count) tunnel managers")
+      guard managers!.count > 0 else {
+        return completion(nil)
       }
-      completion(manager)
+      let manager: NETunnelProviderManager = managers!.first!
+      if manager.isStale {
+        DDLogInfo("Removing stale tunnel manager")
+        manager.removeFromPreferences() { _ in
+          return completion(nil)
+        }
+      } else {
+        return completion(manager)
+      }
+    }
+  }
+
+  // Updates the application's tunnel provider manager in the VPN preferences.
+  private func saveTunnelManager(_ manager: NETunnelProviderManager, _ completion: @escaping ((Bool) -> Void)) {
+    manager.saveToPreferences() { error  in
+      guard error == nil else {
+        DDLogError("Failed to save VPN configuration: \(error)")
+        return completion(false)
+      }
+      self.tunnelManager = manager
+      self.observeVpnStatusChange(self.tunnelManager!)
+      NotificationCenter.default.post(name: .NEVPNConfigurationChange, object: nil)
+      // Workaround for https://forums.developer.apple.com/thread/25928
+      self.tunnelManager?.loadFromPreferences() { error in
+        if let error = error {
+          DDLogError("Failed to get tunnel manager: \(error)")
+          return completion(false)
+        }
+        DDLogInfo("Saved VPN configuration")
+        return completion(true)
+      }
     }
   }
 


### PR DESCRIPTION
Internally, iOS and macOS use different techniques for identifying code. A macOS-style link in the provider configuration fails to find iOS-style providers. We track whether we need to do this with a version in the [`providerConfiguration`](https://developer.apple.com/documentation/networkextension/netunnelproviderprotocol/1406206-providerconfiguration).