### PR TITLE
feat(client/cordova/apple): [1980] randomize list of dns severs

### DIFF
--- a/client/src/cordova/apple/OutlineAppleLib/Sources/OutlineTunnel/OutlineTunnel.swift
+++ b/client/src/cordova/apple/OutlineAppleLib/Sources/OutlineTunnel/OutlineTunnel.swift
@@ -70,6 +70,8 @@ public class OutlineTunnel: NSObject, Codable {
     @objc public static func getTunnelNetworkSettings(tunnelRemoteAddress: String) -> NEPacketTunnelNetworkSettings {
         // The remote address is not used for routing, but for display in Settings > VPN > Outline.
         let settings = NEPacketTunnelNetworkSettings(tunnelRemoteAddress: tunnelRemoteAddress)
+        var dnsList = ["1.1.1.1", "9.9.9.9", "208.67.222.222", "208.67.220.220"]
+        dnsList.shuffle()
 
         // Configure VPN address and routing.
         let vpnAddress = selectVpnAddress(interfaceAddresses: getNetworkInterfaceAddresses())
@@ -79,8 +81,8 @@ public class OutlineTunnel: NSObject, Codable {
         settings.ipv4Settings = ipv4Settings
 
         // Configure with Cloudflare, Quad9, and OpenDNS resolver addresses.
-        settings.dnsSettings = NEDNSSettings(servers: ["1.1.1.1", "9.9.9.9", "208.67.222.222", "208.67.220.220"])
-        
+        settings.dnsSettings = NEDNSSettings(servers: dnsList)
+
         return settings
     }
 }

--- a/client/src/cordova/apple/OutlineAppleLib/Tests/OutlineTunnelTest/OutlineTunnelTest.swift
+++ b/client/src/cordova/apple/OutlineAppleLib/Tests/OutlineTunnelTest/OutlineTunnelTest.swift
@@ -26,7 +26,7 @@ final class OutlineTunnelTest: XCTestCase {
     
     func testGetTunnelNetworkSettings() {
         let settings = OutlineTunnel.getTunnelNetworkSettings(tunnelRemoteAddress: "1.2.3.4")
-        
+
         XCTAssertEqual("1.2.3.4", settings.tunnelRemoteAddress)
         
         XCTAssertEqual(1, settings.ipv4Settings?.addresses.count)
@@ -36,6 +36,9 @@ final class OutlineTunnelTest: XCTestCase {
         XCTAssertEqual([NEIPv4Route.default()], settings.ipv4Settings?.includedRoutes)
         XCTAssertEqual(15, settings.ipv4Settings?.excludedRoutes?.count ?? 0)
 
-        XCTAssertEqual(["1.1.1.1", "9.9.9.9", "208.67.222.222", "208.67.220.220"], settings.dnsSettings?.servers)
+        XCTAssertEqual(settings.dnsSettings?.servers.contains("1.1.1.1"), true)
+        XCTAssertEqual(settings.dnsSettings?.servers.contains("9.9.9.9"), true)
+        XCTAssertEqual(settings.dnsSettings?.servers.contains("208.67.222.222"), true)
+        XCTAssertEqual(settings.dnsSettings?.servers.contains("208.67.220.220"), true)
     }
 }


### PR DESCRIPTION
Just add a simple shuffle for list of dns servers

According to issue https://github.com/Jigsaw-Code/outline-apps/issues/1980 