### PR TITLE
chore(client/ios): update CordovaLib's deployment target

### DIFF
--- a/client/config.xml
+++ b/client/config.xml
@@ -71,7 +71,7 @@
 
     <!-- iOS -->
     <platform name="ios">
-        <preference name="deployment-target" value="11.0" />
+        <preference name="deployment-target" value="13.1" />
         <preference name="scheme" value="app" />
         <preference name="hostname" value="localhost" />
         <preference name="DisallowOverscroll" value="true" />


### PR DESCRIPTION
```
/Users/sbruens/work/temp-outline-apps/client/platforms/ios/CordovaLib/CordovaLib.xcodeproj: warning: The iOS deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 11.0, but the range of supported deployment target versions is 12.0 to 18.0.99. (in target 'CordovaLib' from project 'CordovaLib')
```