### PR TITLE
Add arm64 Linux version of client

### DIFF
--- a/.github/workflows/build_and_test_debug_client.yml
+++ b/.github/workflows/build_and_test_debug_client.yml
@@ -102,6 +102,41 @@ jobs:
       - name: Build Linux Client
         run: npm run action client/electron/build linux
 
+  linux_arm64_debug_build:
+    name: Linux arm64 Debug Build
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 20
+    needs: [web_test, backend_test]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: ./package-lock.json
+
+      - name: Install NPM Dependencies
+        run: |
+          sudo apt update && sudo apt install chromium-browser
+          npm ci
+
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: '${{ github.workspace }}/go.mod'
+
+      - name: Build Linux Client
+        # electron-builder has no arm64 version fpm, so install it from
+        # gem and force to use system one. Based on this workaround:
+        # https://github.com/jordansissel/fpm/issues/1801#issuecomment-919877499
+        run: |
+          sudo gem install fpm
+          export USE_SYSTEM_FPM=true
+          npm run action client/electron/build linux -- --arch arm64
+
   windows_debug_build:
     name: Windows Debug Build
     runs-on: windows-2019

--- a/client/build/get_build_parameters.mjs
+++ b/client/build/get_build_parameters.mjs
@@ -14,7 +14,15 @@
 
 import minimist from 'minimist';
 
-const VALID_PLATFORMS = ['linux', 'windows', 'ios', 'macos', 'maccatalyst', 'android', 'browser'];
+const VALID_PLATFORMS = [
+  'linux',
+  'windows',
+  'ios',
+  'macos',
+  'maccatalyst',
+  'android',
+  'browser',
+];
 const VALID_BUILD_MODES = ['debug', 'release'];
 
 const MS_PER_HOUR = 1000 * 60 * 60;
@@ -54,7 +62,8 @@ export function getBuildParameters(cliArguments) {
     platform,
     buildMode,
     verbose,
-    versionName: buildMode === 'release' ? versionName : `${versionName}-${buildMode}`,
+    versionName:
+      buildMode === 'release' ? versionName : `${versionName}-${buildMode}`,
     sentryDsn,
     buildNumber: Math.floor(Date.now() / MS_PER_HOUR),
     arch,

--- a/client/build/get_build_parameters.mjs
+++ b/client/build/get_build_parameters.mjs
@@ -33,6 +33,7 @@ export function getBuildParameters(cliArguments) {
     verbose = false,
     versionName = '0.0.0',
     sentryDsn = process.env.SENTRY_DSN,
+    arch = '',
   } = minimist(cliArguments);
 
   if (platform && !VALID_PLATFORMS.includes(platform)) {
@@ -56,5 +57,6 @@ export function getBuildParameters(cliArguments) {
     versionName: buildMode === 'release' ? versionName : `${versionName}-${buildMode}`,
     sentryDsn,
     buildNumber: Math.floor(Date.now() / MS_PER_HOUR),
+    arch,
   };
 }

--- a/client/electron/electron-builder.json
+++ b/client/electron/electron-builder.json
@@ -39,9 +39,6 @@
       "arch": [
         "x64"
       ],
-      "target": "AppImage"
-    }, {
-      "arch": "x64",
       "target": "deb"
     }]
   },

--- a/client/electron/electron-builder.json
+++ b/client/electron/electron-builder.json
@@ -1,6 +1,6 @@
 {
   "productName": "Outline",
-  "artifactName": "Outline-Client.${ext}",
+  "artifactName": "Outline-Client-${arch}.${ext}",
   "asarUnpack": [ "client" ],
   "directories": {
     "buildResources": "output/client/electron",
@@ -37,7 +37,8 @@
     "maintainer": "Jigsaw LLC",
     "target": [{
       "arch": [
-        "x64"
+        "x64",
+        "arm64"
       ],
       "target": "deb"
     }]

--- a/client/go/Taskfile.yml
+++ b/client/go/Taskfile.yml
@@ -65,6 +65,10 @@ tasks:
     desc: "Build the tun2socks binary and library for Linux"
     cmds: [{task: electron, vars: {TARGET_OS: "linux", TARGET_ARCH: "amd64"}}]
 
+  linux_arm64:
+    desc: "Build the tun2socks binary and library for Linux"
+    cmds: [{task: electron, vars: {TARGET_OS: "linux", TARGET_ARCH: "arm64"}}]
+
   android:
     desc: "Build the tun2socks.aar library for Android"
     vars:

--- a/client/go/build.action.mjs
+++ b/client/go/build.action.mjs
@@ -24,9 +24,17 @@ import {getBuildParameters} from '../build/get_build_parameters.mjs';
  * @param {string[]} parameters
  */
 export async function main(...parameters) {
-  const {platform: targetPlatform, arch: targetArch} = getBuildParameters(parameters);
-  const targetName = targetArch !== '' ? `${targetPlatform}_${targetArch}` : targetPlatform;
-  await spawnStream('go', 'run', 'github.com/go-task/task/v3/cmd/task', '-v', `client:tun2socks:${targetName}`);
+  const {platform: targetPlatform, arch: targetArch} =
+    getBuildParameters(parameters);
+  const targetName =
+    targetArch !== '' ? `${targetPlatform}_${targetArch}` : targetPlatform;
+  await spawnStream(
+    'go',
+    'run',
+    'github.com/go-task/task/v3/cmd/task',
+    '-v',
+    `client:tun2socks:${targetName}`
+  );
 }
 
 if (import.meta.url === url.pathToFileURL(process.argv[1]).href) {

--- a/client/go/build.action.mjs
+++ b/client/go/build.action.mjs
@@ -24,8 +24,9 @@ import {getBuildParameters} from '../build/get_build_parameters.mjs';
  * @param {string[]} parameters
  */
 export async function main(...parameters) {
-  const {platform: targetPlatform} = getBuildParameters(parameters);
-  await spawnStream('go', 'run', 'github.com/go-task/task/v3/cmd/task', '-v', `client:tun2socks:${targetPlatform}`);
+  const {platform: targetPlatform, arch: targetArch} = getBuildParameters(parameters);
+  const targetName = targetArch !== '' ? `${targetPlatform}_${targetArch}` : targetPlatform;
+  await spawnStream('go', 'run', 'github.com/go-task/task/v3/cmd/task', '-v', `client:tun2socks:${targetName}`);
 }
 
 if (import.meta.url === url.pathToFileURL(process.argv[1]).href) {


### PR DESCRIPTION
I'm not sure that it's best solution, but it's working example.
It was based on my previous build instruction: https://github.com/Jigsaw-Code/outline-apps/issues/816#issuecomment-2568454963
But improved + added arm64 Linux CI with GitHub-hosted runner:
https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#standard-github-hosted-runners-for-public-repositories