### PR TITLE
[DO-NOT-MERGE] fix(manager/macos): restore app bundle ID to `outline-manager`

### DIFF
--- a/server_manager/electron/electron_builder.json
+++ b/server_manager/electron/electron_builder.json
@@ -1,6 +1,9 @@
 {
   "asarUnpack": ["server_manager/www/images"],
   "artifactName": "Outline-Manager.${ext}",
+  "extraMetadata": {
+    "name": "outline-manager"
+  },
   "linux": {
     "icon": "icons/png",
     "category": "Network",


### PR DESCRIPTION
This PR restores the Outline Manager's `CFBundleIdentifier` back to `com.electron.outline-manager`.

```
Local: [com.electron.outline-manager]
```

Here are the list of the `CFBundleIdentifier` of all our released Outline Managers:

```
1.10.0: [com.electron.outline-manager]
1.11.0: [com.electron.outline-manager]
1.12.0: [com.electron.outline-manager]
1.13.0: [com.electron.outline-manager]
1.14.0: [com.electron.outline-manager]
1.15.0: [com.electron.outline-manager]
1.15.1: [com.electron.outline-manager]
1.15.2: [com.electron.outline-manager]
1.16.0: [com.electron.outlineservermanager]
stable: [com.electron.outlineservermanager]
```

**Note:** this change is critical for auto-update, mismatched `CFBundleIdentifier` will cause auto-update to fail. Let's  discuss offline before merging and releasing.