### PR TITLE
feat(manager): add binary unit (KiB/MiB/GiB) tooltips to bandwidth and data displays

### DIFF
--- a/server_manager/www/views/server_view/access_key_data_table/access_key_usage_meter/index.ts
+++ b/server_manager/www/views/server_view/access_key_data_table/access_key_usage_meter/index.ts
@@ -18,7 +18,9 @@ import {LitElement, html, css, nothing} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 import {classMap} from 'lit/directives/class-map.js';
 
-import {formatBytes} from '../../../../data_formatting';
+import {formatBinaryBytes, formatBytes} from '../../../../data_formatting';
+
+import '../../icon_tooltip';
 
 @customElement('access-key-usage-meter')
 export class AccessKeyUsageMeter extends LitElement {
@@ -58,8 +60,8 @@ export class AccessKeyUsageMeter extends LitElement {
       font-family: var(--access-key-usage-meter-font-family);
     }
 
-    :host([dataLimitWarning]) > label,
-    label.data-limit-warning {
+    :host([dataLimitWarning]) > .label-container > label,
+    .label-container > label.data-limit-warning {
       color: var(--access-key-usage-meter-warning-text-color);
     }
 
@@ -83,6 +85,17 @@ export class AccessKeyUsageMeter extends LitElement {
     progress.data-limit-warning[value]::-webkit-progress-value {
       background: var(--access-key-usage-meter-warning-color);
     }
+
+    .label-container {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+    }
+
+    .label-container icon-tooltip {
+      --icon-tooltip-icon-size: 0.75rem;
+      --icon-tooltip-button-size: 1rem;
+    }
   `;
 
   render() {
@@ -95,17 +108,33 @@ export class AccessKeyUsageMeter extends LitElement {
         max=${this.dataLimitBytes}
         value=${this.dataUsageBytes}
       ></progress>
-      <label
-        class=${classMap({
-          'data-limit-warning': this.dataLimitWarning,
-        })}
-        for="progress"
-      >
-        ${formatBytes(this.dataUsageBytes, this.language)} /
-        ${formatBytes(this.dataLimitBytes, this.language)}
-        ${this.dataLimitWarning
-          ? `(${this.localize('server-view-access-keys-usage-limit')})`
-          : nothing}
-      </label>`;
+      <span class="label-container">
+        <label
+          class=${classMap({
+            'data-limit-warning': this.dataLimitWarning,
+          })}
+          for="progress"
+        >
+          ${formatBytes(this.dataUsageBytes, this.language)} /
+          ${formatBytes(this.dataLimitBytes, this.language)}
+          ${this.dataLimitWarning
+            ? `(${this.localize('server-view-access-keys-usage-limit')})`
+            : nothing}
+        </label>
+        <icon-tooltip
+          text="${this.formatBinaryTooltip()}"
+          icon="info"
+        ></icon-tooltip>
+      </span>`;
+  }
+
+  /**
+   * Formats the usage and limit values with binary units for tooltip display.
+   *
+   * @returns Formatted string showing "usage / limit" in binary units (KiB, MiB, GiB)
+   */
+  private formatBinaryTooltip(): string {
+    return `${formatBinaryBytes(this.dataUsageBytes, this.language)} /
+      ${formatBinaryBytes(this.dataLimitBytes, this.language)}`;
   }
 }

--- a/server_manager/www/views/server_view/access_key_data_table/access_key_usage_meter/index.ts
+++ b/server_manager/www/views/server_view/access_key_data_table/access_key_usage_meter/index.ts
@@ -60,8 +60,8 @@ export class AccessKeyUsageMeter extends LitElement {
       font-family: var(--access-key-usage-meter-font-family);
     }
 
-    :host([dataLimitWarning]) > .label-container > label,
-    .label-container > label.data-limit-warning {
+    :host([dataLimitWarning]) > label,
+    label.data-limit-warning {
       color: var(--access-key-usage-meter-warning-text-color);
     }
 
@@ -85,17 +85,6 @@ export class AccessKeyUsageMeter extends LitElement {
     progress.data-limit-warning[value]::-webkit-progress-value {
       background: var(--access-key-usage-meter-warning-color);
     }
-
-    .label-container {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.25rem;
-    }
-
-    .label-container icon-tooltip {
-      --icon-tooltip-icon-size: 0.75rem;
-      --icon-tooltip-button-size: 1rem;
-    }
   `;
 
   render() {
@@ -108,7 +97,7 @@ export class AccessKeyUsageMeter extends LitElement {
         max=${this.dataLimitBytes}
         value=${this.dataUsageBytes}
       ></progress>
-      <span class="label-container">
+      <icon-tooltip text="${this.formatDataUsageFractionBinaryTooltip()}">
         <label
           class=${classMap({
             'data-limit-warning': this.dataLimitWarning,
@@ -121,11 +110,7 @@ export class AccessKeyUsageMeter extends LitElement {
             ? `(${this.localize('server-view-access-keys-usage-limit')})`
             : nothing}
         </label>
-        <icon-tooltip
-          text="${this.formatBinaryTooltip()}"
-          icon="info"
-        ></icon-tooltip>
-      </span>`;
+      </icon-tooltip>`;
   }
 
   /**
@@ -133,7 +118,7 @@ export class AccessKeyUsageMeter extends LitElement {
    *
    * @returns Formatted string showing "usage / limit" in binary units (KiB, MiB, GiB)
    */
-  private formatBinaryTooltip(): string {
+  private formatDataUsageFractionBinaryTooltip(): string {
     return `${formatBinaryBytes(this.dataUsageBytes, this.language)} /
       ${formatBinaryBytes(this.dataLimitBytes, this.language)}`;
   }

--- a/server_manager/www/views/server_view/icon_tooltip/index.ts
+++ b/server_manager/www/views/server_view/icon_tooltip/index.ts
@@ -22,10 +22,14 @@ import '@material/mwc-icon-button';
 
 // TODO (#2384): this tooltip is implemented by javascript and not css due to api limitations in our current version of Electron.
 // Once electron is updated, we should switch to the Popover API for better style control.
+
+type TooltipPosition = 'bottom' | 'right' | 'left' | 'top';
+
 @customElement('icon-tooltip')
 export class IconTooltip extends LitElement {
   @property({type: String}) text?: string;
   @property({type: String}) icon: string = 'help';
+  @property({type: String}) position: TooltipPosition = 'bottom';
 
   @state() tooltip?: HTMLElement;
   @query('mwc-icon-button') iconElement: HTMLElement;
@@ -75,6 +79,9 @@ export class IconTooltip extends LitElement {
     this.tooltip = document.createElement('span');
     this.tooltip.innerHTML = this.text;
 
+    const rect = this.iconElement.getBoundingClientRect();
+    const positioning = this.calculatePosition(rect);
+
     // Since this element is created outside the custom element's scope,
     // we can't style it here and instead must inject the styles directly.
     // This too will be resolved by the Popover API
@@ -85,12 +92,10 @@ export class IconTooltip extends LitElement {
       color: hsl(0, 0%, 20%);
       font-family: 'Inter', system-ui;
       max-width: 320px;
-      left: ${this.iconElement.getBoundingClientRect().left}px;
-      top: ${this.iconElement.getBoundingClientRect().bottom}px;
+      ${positioning}
       padding: 0.3rem;
       position: fixed;
       white-space: pre-line;
-      transform: translateX(-50%);
       width: max-content;
       word-wrap: break-word;
       z-index: 1000;
@@ -101,6 +106,60 @@ export class IconTooltip extends LitElement {
     // TODO: sometimes the blur listener gives up when the user navigates away from the application
     // this ensures the tooltip is eventually removed - this will be solved by the Popover API
     setTimeout(this.removeTooltip, 5000);
+  }
+
+  private calculatePosition(rect: DOMRect): string {
+    const spacing = 8;
+    const tooltipMaxWidth = 320;
+    let position = this.position;
+
+    // Auto-adjust if tooltip would go off-screen
+    if (position === 'right' && rect.right + tooltipMaxWidth + spacing > window.innerWidth) {
+      position = 'left';
+    }
+
+    if (position === 'left' && rect.left - tooltipMaxWidth - spacing < 0) {
+      position = 'right';
+    }
+
+    if (position === 'bottom' && rect.bottom + 100 > window.innerHeight) {
+      position = 'top';
+    }
+
+    if (position === 'top' && rect.top - 100 < 0) {
+      position = 'bottom';
+    }
+
+    switch (position) {
+      case 'right':
+        return `
+          left: ${rect.right + spacing}px;
+          top: ${rect.top + rect.height / 2}px;
+          transform: translateY(-50%);
+        `;
+
+      case 'left':
+        return `
+          right: ${window.innerWidth - rect.left + spacing}px;
+          top: ${rect.top + rect.height / 2}px;
+          transform: translateY(-50%);
+        `;
+
+      case 'top':
+        return `
+          left: ${rect.left + rect.width / 2}px;
+          bottom: ${window.innerHeight - rect.top + spacing}px;
+          transform: translateX(-50%);
+        `;
+
+      case 'bottom':
+      default:
+        return `
+          left: ${rect.left + rect.width / 2}px;
+          top: ${rect.bottom + spacing}px;
+          transform: translateX(-50%);
+        `;
+    }
   }
 
   removeTooltip() {

--- a/server_manager/www/views/server_view/icon_tooltip/index.ts
+++ b/server_manager/www/views/server_view/icon_tooltip/index.ts
@@ -51,11 +51,36 @@ export class IconTooltip extends LitElement {
     mwc-icon-button {
       --mdc-icon-button-size: var(--icon-tooltip-button-size);
     }
+
+    .tooltip-trigger {
+      cursor: help;
+      text-decoration: underline dotted;
+      text-decoration-color: currentColor;
+      text-underline-offset: 2px;
+      display: inline;
+    }
   `;
 
   render() {
     if (this.text === undefined) {
       return html`<mwc-icon>${this.icon}</mwc-icon>`;
+    }
+
+    // Check if slot has content
+    const hasSlotContent = this.innerHTML.trim().length > 0;
+
+    // If slot content exists, wrap that instead of showing icon button
+    if (hasSlotContent) {
+      return html`
+        <span
+          class="tooltip-trigger"
+          @click=${this.insertTooltip}
+          @blur=${this.removeTooltip}
+          tabindex="0"
+        >
+          <slot></slot>
+        </span>
+      `;
     }
 
     return html`
@@ -114,7 +139,10 @@ export class IconTooltip extends LitElement {
     let position = this.position;
 
     // Auto-adjust if tooltip would go off-screen
-    if (position === 'right' && rect.right + tooltipMaxWidth + spacing > window.innerWidth) {
+    if (
+      position === 'right' &&
+      rect.right + tooltipMaxWidth + spacing > window.innerWidth
+    ) {
       position = 'left';
     }
 

--- a/server_manager/www/views/server_view/server_metrics_row/bandwidth.ts
+++ b/server_manager/www/views/server_view/server_metrics_row/bandwidth.ts
@@ -287,18 +287,6 @@ export class ServerMetricsBandwidthRow extends LitElement {
         border: none;
       }
     }
-
-    .data-value-with-tooltip {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.25rem;
-    }
-
-    .data-value-with-tooltip icon-tooltip {
-      --icon-tooltip-icon-size: 0.75rem;
-      --icon-tooltip-button-size: 1rem;
-      --icon-tooltip-icon-color: hsla(0, 0%, 100%, 0.5);
-    }
   `;
 
   render() {
@@ -367,7 +355,12 @@ export class ServerMetricsBandwidthRow extends LitElement {
             <div class="current-container">
               <span class="current-value-and-unit">
                 ${this.metrics.bandwidth
-                  ? html`<span class="data-value-with-tooltip">
+                  ? html`<icon-tooltip
+                      text="${this.formatBandwidthBinaryTooltip(
+                        this.metrics.bandwidth.current.data.bytes
+                      )}"
+                      position="right"
+                    >
                       <span class="current-value">
                         ${this.formatBandwidthValue(
                           this.metrics.bandwidth.current.data.bytes
@@ -378,14 +371,7 @@ export class ServerMetricsBandwidthRow extends LitElement {
                           this.metrics.bandwidth.current.data.bytes
                         )}
                       </span>
-                      <icon-tooltip
-                        text="${this.formatBandwidthBinaryTooltip(
-                          this.metrics.bandwidth.current.data.bytes
-                        )}"
-                        icon="info"
-                        position="right"
-                      ></icon-tooltip>
-                    </span>`
+                    </icon-tooltip>`
                   : html`<span class="current-value">-</span>`}
               </span>
               <span class="current-title"
@@ -397,7 +383,11 @@ export class ServerMetricsBandwidthRow extends LitElement {
             <div class="peak-container">
               <span class="peak-value-and-unit">
                 ${this.metrics.bandwidth
-                  ? html`<span class="data-value-with-tooltip">
+                  ? html`<icon-tooltip
+                      text="${this.formatBandwidthBinaryTooltip(
+                        this.metrics.bandwidth.peak.data.bytes
+                      )}"
+                    >
                       <span class="peak-value">
                         ${this.formatBandwidthValue(
                           this.metrics.bandwidth.peak.data.bytes
@@ -408,13 +398,7 @@ export class ServerMetricsBandwidthRow extends LitElement {
                           this.metrics.bandwidth.peak.data.bytes
                         )}
                       </span>
-                      <icon-tooltip
-                        text="${this.formatBandwidthBinaryTooltip(
-                          this.metrics.bandwidth.peak.data.bytes
-                        )}"
-                        icon="info"
-                      ></icon-tooltip>
-                    </span>`
+                    </icon-tooltip>`
                   : html`<span class="peak-value">-</span>`}
                 ${this.metrics.bandwidth?.peak.timestamp
                   ? html`<span class="peak-timestamp"
@@ -448,37 +432,33 @@ export class ServerMetricsBandwidthRow extends LitElement {
     }
 
     if (this.dataLimitBytes === 0) {
-      return html`<span class="data-value-with-tooltip">
+      return html`<icon-tooltip
+        text="${this.formatDataAmountBinaryTooltip(
+          this.metrics.dataTransferred.bytes
+        )}"
+        position="right"
+      >
         <span class="bandwidth-percentage">
           ${formatBytes(this.metrics.dataTransferred.bytes, this.language)}
         </span>
-        <icon-tooltip
-          text="${this.formatDataAmountBinaryTooltip(
-            this.metrics.dataTransferred.bytes
-          )}"
-          icon="info"
-          position="right"
-        ></icon-tooltip>
-      </span>`;
+      </icon-tooltip>`;
     }
 
     return html`<span class="bandwidth-percentage">
         ${this.formatPercentage(this.bandwidthPercentage)}
       </span>
-      <span class="data-value-with-tooltip">
+      <icon-tooltip
+        text="${this.formatDataAmountBinaryTooltip(
+          this.metrics.dataTransferred.bytes
+        )}
+        / ${this.formatDataAmountBinaryTooltip(this.dataLimitBytes)}"
+        position="right"
+      >
         <span class="bandwidth-fraction">
           ${formatBytes(this.metrics.dataTransferred.bytes, this.language)} /
           ${formatBytes(this.dataLimitBytes, this.language)}
         </span>
-        <icon-tooltip
-          text="${this.formatDataAmountBinaryTooltip(
-            this.metrics.dataTransferred.bytes
-          )}
-          / ${this.formatDataAmountBinaryTooltip(this.dataLimitBytes)}"
-          icon="info"
-          position="right"
-        ></icon-tooltip>
-      </span>
+      </icon-tooltip>
       <span class="bandwidth-progress-container">
         <progress
           max=${this.dataLimitBytes}

--- a/server_manager/www/views/server_view/server_metrics_row/bandwidth.ts
+++ b/server_manager/www/views/server_view/server_metrics_row/bandwidth.ts
@@ -383,6 +383,7 @@ export class ServerMetricsBandwidthRow extends LitElement {
                           this.metrics.bandwidth.current.data.bytes
                         )}"
                         icon="info"
+                        position="right"
                       ></icon-tooltip>
                     </span>`
                   : html`<span class="current-value">-</span>`}
@@ -456,6 +457,7 @@ export class ServerMetricsBandwidthRow extends LitElement {
             this.metrics.dataTransferred.bytes
           )}"
           icon="info"
+          position="right"
         ></icon-tooltip>
       </span>`;
     }
@@ -474,6 +476,7 @@ export class ServerMetricsBandwidthRow extends LitElement {
           )}
           / ${this.formatDataAmountBinaryTooltip(this.dataLimitBytes)}"
           icon="info"
+          position="right"
         ></icon-tooltip>
       </span>
       <span class="bandwidth-progress-container">

--- a/server_manager/www/views/server_view/server_metrics_row/index.ts
+++ b/server_manager/www/views/server_view/server_metrics_row/index.ts
@@ -117,9 +117,10 @@ export class ServerMetricsRow extends LitElement {
 
                 <div class="subcards-container">
                   ${this.subcards.map(
-                    ({highlight, title, subtitle, icon}) => html`
+                    ({highlight, highlightTooltip, title, subtitle, icon}) => html`
                       <server-metrics-row-subcard
                         highlight=${ifDefined(highlight)}
+                        highlightTooltip=${ifDefined(highlightTooltip)}
                         title=${ifDefined(title)}
                         subtitle=${ifDefined(subtitle)}
                         icon=${ifDefined(icon)}

--- a/server_manager/www/views/server_view/server_metrics_row/index.ts
+++ b/server_manager/www/views/server_view/server_metrics_row/index.ts
@@ -117,7 +117,13 @@ export class ServerMetricsRow extends LitElement {
 
                 <div class="subcards-container">
                   ${this.subcards.map(
-                    ({highlight, highlightTooltip, title, subtitle, icon}) => html`
+                    ({
+                      highlight,
+                      highlightTooltip,
+                      title,
+                      subtitle,
+                      icon,
+                    }) => html`
                       <server-metrics-row-subcard
                         highlight=${ifDefined(highlight)}
                         highlightTooltip=${ifDefined(highlightTooltip)}

--- a/server_manager/www/views/server_view/server_metrics_row/server_metrics_row_subcard/index.ts
+++ b/server_manager/www/views/server_view/server_metrics_row/server_metrics_row_subcard/index.ts
@@ -65,12 +65,10 @@ export class ServerMetricsRowSubcard extends LitElement {
     }
 
     .highlight {
-      align-items: center;
       background-color: var(--server-metrics-row-subcard-highlight-color);
       border-radius: var(--server-metrics-row-subcard-border-radius);
       border: var(--server-metrics-row-subcard-highlight-border);
-      display: inline-flex;
-      gap: 0.25rem;
+      display: inline-block;
       font-size: var(--server-metrics-row-subcard-highlight-font-size);
       margin-bottom: var(--server-metrics-row-subcard-highlight-margin-bottom);
       padding: var(--server-metrics-row-subcard-highlight-padding);
@@ -86,28 +84,20 @@ export class ServerMetricsRowSubcard extends LitElement {
       font-size: var(--server-metrics-row-subcard-subtitle-font-size);
       font-weight: bold;
     }
-
-    .highlight icon-tooltip {
-      --icon-tooltip-icon-size: 0.75rem;
-      --icon-tooltip-button-size: 1rem;
-      --icon-tooltip-icon-color: hsla(0, 0%, 100%, 0.5);
-    }
   `;
 
   render() {
     return html`
       <div>
         ${this.highlight
-          ? html`<mark class="highlight">
-              ${this.highlight}
-              ${this.highlightTooltip
-                ? html`<icon-tooltip
-                    text="${this.highlightTooltip}"
-                    icon="info"
-                    position="right"
-                  ></icon-tooltip>`
-                : nothing}
-            </mark>`
+          ? this.highlightTooltip
+            ? html`<icon-tooltip
+                text="${this.highlightTooltip}"
+                position="right"
+              >
+                <mark class="highlight">${this.highlight}</mark>
+              </icon-tooltip>`
+            : html`<mark class="highlight">${this.highlight}</mark>`
           : nothing}
         ${this.title ? html`<h4 class="title">${this.title}</h4>` : nothing}
         ${this.subtitle

--- a/server_manager/www/views/server_view/server_metrics_row/server_metrics_row_subcard/index.ts
+++ b/server_manager/www/views/server_view/server_metrics_row/server_metrics_row_subcard/index.ts
@@ -17,9 +17,12 @@
 import {LitElement, html, css, nothing} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 
+import '../../icon_tooltip';
+
 @customElement('server-metrics-row-subcard')
 export class ServerMetricsRowSubcard extends LitElement {
   @property({type: String}) highlight?: string;
+  @property({type: String}) highlightTooltip?: string;
   @property({type: String}) title: string;
   @property({type: String}) subtitle?: string;
   @property({type: String}) icon?: string;
@@ -62,10 +65,12 @@ export class ServerMetricsRowSubcard extends LitElement {
     }
 
     .highlight {
+      align-items: center;
       background-color: var(--server-metrics-row-subcard-highlight-color);
       border-radius: var(--server-metrics-row-subcard-border-radius);
       border: var(--server-metrics-row-subcard-highlight-border);
-      display: inline-block;
+      display: inline-flex;
+      gap: 0.25rem;
       font-size: var(--server-metrics-row-subcard-highlight-font-size);
       margin-bottom: var(--server-metrics-row-subcard-highlight-margin-bottom);
       padding: var(--server-metrics-row-subcard-highlight-padding);
@@ -81,13 +86,27 @@ export class ServerMetricsRowSubcard extends LitElement {
       font-size: var(--server-metrics-row-subcard-subtitle-font-size);
       font-weight: bold;
     }
+
+    .highlight icon-tooltip {
+      --icon-tooltip-icon-size: 0.75rem;
+      --icon-tooltip-button-size: 1rem;
+      --icon-tooltip-icon-color: hsla(0, 0%, 100%, 0.5);
+    }
   `;
 
   render() {
     return html`
       <div>
         ${this.highlight
-          ? html`<mark class="highlight">${this.highlight}</mark>`
+          ? html`<mark class="highlight">
+              ${this.highlight}
+              ${this.highlightTooltip
+                ? html`<icon-tooltip
+                    text="${this.highlightTooltip}"
+                    icon="info"
+                  ></icon-tooltip>`
+                : nothing}
+            </mark>`
           : nothing}
         ${this.title ? html`<h4 class="title">${this.title}</h4>` : nothing}
         ${this.subtitle

--- a/server_manager/www/views/server_view/server_metrics_row/server_metrics_row_subcard/index.ts
+++ b/server_manager/www/views/server_view/server_metrics_row/server_metrics_row_subcard/index.ts
@@ -104,6 +104,7 @@ export class ServerMetricsRowSubcard extends LitElement {
                 ? html`<icon-tooltip
                     text="${this.highlightTooltip}"
                     icon="info"
+                    position="right"
                   ></icon-tooltip>`
                 : nothing}
             </mark>`


### PR DESCRIPTION
Fixes #2150

## Summary

Adds icon-tooltips showing binary units (KiB, MiB, GiB) alongside SI units (KB, MB, GB) throughout the Manager UI. Users familiar with binary units can now view data in their preferred format without changing the primary display.

## Changes

Core Utilities (`data_formatting.ts`)
- Added `formatBinaryBytes()` with i18n support via `Intl.NumberFormat`
- Added helper functions and binary unit constants (1024-based)

Tooltip Infrastructure (`icon_tooltip/index.ts`)
- Added configurable `position` property (bottom/right/left/top)
- Implemented auto-positioning to prevent off-screen rendering
- Applied to metrics to prevent UI overlap

UI Components
- Extended `server-metrics-row-subcard` with optional `highlightTooltip` property
- Added binary tooltips to bandwidth metrics (current, peak, total, ASN breakdown)
- Added binary tooltips to access key data usage meters

Note: Uses `icon-tooltip` component like existing patterns in table headers instead of native `title` attribute due to Electron Shadow DOM limitations that prevent native tooltips from displaying.

## Screenshots

### Bandwidth Metrics - Main Display
<img width="1094" height="217" alt="Screenshot of main bandwidth panel showing total bandwidth usage, current/peak bandwidth values with info icons. Screenshot shows tooltip to the right of the info icon next to total bandwidth value" src="https://github.com/user-attachments/assets/717ad159-24f8-4ae7-9815-733cdd8d8baa" />

Tooltip positions for this panel:
1. total bandwidth: right
2. current bandwidth: right
3. peak bandwidth: bottom

### ASN Breakdown Inline Tooltips
<img width="1792" height="586" alt="Screenshot comparing ASN table with info icons inside highlight chips. Comparison shows how the chips look like in default state and when the tooltip appears on click." src="https://github.com/user-attachments/assets/2c56a9df-2c5a-4858-bf92-642670666912" />

Info icons next to bandwidth values inside highlight chip for each AS.

### Access Keys Data Usage
<img width="4276" height="1638" alt="image" src="https://github.com/user-attachments/assets/b33c4696-7335-43c5-8a23-89c3d96c3868" />

Binary value as tooltips for usage fractions (e.g., "403.42 MiB / 762.94 MiB")*

## Key Design Decisions

- Tooltips default to `bottom` position (existing behavior)
- Use `right` position for inline values to prevent overlap
- Auto-adjust when rendering would go off-screen

## Testing

- Verified tooltips display correctly in Electron
- Tested tooltip positioning with various screen sizes
- Confirmed i18n formatting works across locales (de, fr, ja, etc.).

## Known Issues

- Binary units (KiB, MiB, GiB) don't appear to have CLDR or `Intl.NumberFormat` translations. Numbers have been internationalized and units hardcoded. Suggestions for a better way to handle this would be really helpful!
- Sometimes auto-positioning might overlap on existing UI elements. For instance, current bandwidth tooltip switches from right to left and hides the bytes value on smaller screens.
