### PR TITLE
feat(client): Use Maestro for UI testing

### DIFF
--- a/client/maestro_test.yaml
+++ b/client/maestro_test.yaml
@@ -1,0 +1,43 @@
+appId: org.outline.android.client
+---
+- launchApp:
+    clearState: true
+- extendedWaitUntil:
+    visible: "GOT IT"
+    timeout: 10000
+- tapOn: "GOT IT"
+
+# Add first server
+- tapOn: "Paste access key here"
+- inputText: "ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTp0ZXN0@192.168.1.1:1234#TestServer1"
+- tapOn: "Confirm"
+- waitForAnimationToEnd
+
+# Add second server
+- tapOn: "Add server"
+- tapOn: "Paste access key here"
+- inputText: "ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTp0ZXN0@192.168.1.2:1234#TestServer2"
+- tapOn: "Confirm"
+- waitForAnimationToEnd
+
+# Delete the First Server
+# - tapOn:
+#     rightOf: "server-name"
+# - extendedWaitUntil:
+#     visible: "Forget" # The menu option to delete the server
+#     timeout: 2000
+# - tapOn: "Forget"
+# - waitForAnimationToEnd
+
+# Check App Version in About Page
+# Open the side drawer by tapping the hamburger menu
+- tapOn: "Menu"
+- extendedWaitUntil:
+    visible: "About"
+    timeout: 2000
+- tapOn: "About"
+- waitForAnimationToEnd
+# The about page displays the version, e.g., "Version 1.13.0".
+# Since the version changes, we assert that a text containing "Version" is visible.
+- assertVisible: "Version .*"
+- tapOn: "Back"

--- a/client/web/views/root_view/root_header/index.ts
+++ b/client/web/views/root_view/root_header/index.ts
@@ -52,14 +52,15 @@ export class RootHeader extends LitElement {
   render() {
     return html`<header>
       ${this.showBackButton
-        ? html`<md-icon-button @click=${this.returnHome}>
+        ? html`<md-icon-button aria-label="Back" @click=${this.returnHome}>
             <md-icon>arrow_back</md-icon>
           </md-icon-button>`
-        : html`<md-icon-button @click=${this.openNavigation}>
+        : html`<md-icon-button aria-label="Menu" @click=${this.openNavigation}>
             <md-icon>menu</md-icon>
           </md-icon-button>`}
       <h1>${this.title || 'Outline'}</h1>
       <md-icon-button
+        aria-label="Add server"
         class=${classMap({hidden: !this.showAddButton})}
         @click=${this.openAddAccessKey}
       >

--- a/client/web/views/servers_view/server_list_item/server_card/index.ts
+++ b/client/web/views/servers_view/server_list_item/server_card/index.ts
@@ -313,7 +313,7 @@ export class ServerCard extends LitElement implements ServerListItemElement {
             </div>
           </div>
         </div>
-        <md-icon-button class="card-menu-button" @click=${this.openMenu}>
+        <md-icon-button aria-label="Server options" class="card-menu-button" @click=${this.openMenu}>
           <md-icon>more_vert</md-icon>
         </md-icon-button>
         <footer class="card-footer">


### PR DESCRIPTION
Uses [Maestro](https://maestro.dev/) to automate UI testing.

It's quite easy to use! However, the "more" button on the server card didn't work.
Aria labels help with tap targeting, and accessibility, but they should be internationalized.

Recipe:

```sh
npm run action client/src/cordova/build android && adb install -r -d client/platforms/android/app/build/outputs/apk/debug/app-debug.apk
cd client
maestro test maestro_test.yaml
```

<img width="860" height="448" alt="image" src="https://github.com/user-attachments/assets/da073bd1-01bd-4de9-aab7-507b1e12ef83" />


/cc @ohnorobo FYI, something to explore

There are some cool things, like screen recording and screenshotting capabilities.

Of note: Maestro only supports mobile apps, not the browser on desktop. Playwright might be a better option.