### PR TITLE
feat: copy arm64 install script update

### DIFF
--- a/server_manager/install_scripts/install_server.sh
+++ b/server_manager/install_scripts/install_server.sh
@@ -445,8 +445,8 @@ function set_hostname() {
 install_shadowbox() {
   local MACHINE_TYPE
   MACHINE_TYPE="$(uname -m)"
-  if [[ "${MACHINE_TYPE}" != "x86_64" ]]; then
-    log_error "Unsupported machine type: ${MACHINE_TYPE}. Please run this script on a x86_64 machine"
+  if [[ "${MACHINE_TYPE}" != "x86_64" && "${MACHINE_TYPE}" != "aarch64" && "${MACHINE_TYPE}" != "arm64" ]]; then
+    log_error "Unsupported machine type: ${MACHINE_TYPE}. Supported architectures: x86_64, aarch64/arm64."
     exit 1
   fi
 

--- a/server_manager/install_scripts/install_server.sh
+++ b/server_manager/install_scripts/install_server.sh
@@ -450,8 +450,8 @@ function set_hostname() {
 install_shadowbox() {
   local MACHINE_TYPE
   MACHINE_TYPE="$(uname -m)"
-  if [[ "${MACHINE_TYPE}" != "x86_64" ]]; then
-    log_error "Unsupported machine type: ${MACHINE_TYPE}. Please run this script on a x86_64 machine"
+  if [[ "${MACHINE_TYPE}" != "x86_64" && "${MACHINE_TYPE}" != "aarch64" && "${MACHINE_TYPE}" != "arm64" ]]; then
+    log_error "Unsupported machine type: ${MACHINE_TYPE}. Supported architectures: x86_64, aarch64/arm64."
     exit 1
   fi
 


### PR DESCRIPTION
This is a copy of @oceanapplications install script update from https://github.com/OutlineFoundation/outline-server/pull/1700

This removes a check in the install script which disallowed arm64 machines. But per https://github.com/OutlineFoundation/outline-server/pull/1700 CI and user testing arm64 does work.

This will require a server release to pick up the taskfile changes: https://github.com/OutlineFoundation/outline-server/pull/1700/changes#diff-f1d02bdf4c6eae0cd8305fa3c0081dc6899415740812e098c70b99abf0e7b465
DO NOT MERGE until after that release.