### PR TITLE
fix(electron): fix electron start issues

### DIFF
--- a/client/electron/index.ts
+++ b/client/electron/index.ts
@@ -272,6 +272,12 @@ function createTrayIconImage(imageName: string) {
   if (image.isEmpty()) {
     throw new Error(`cannot find ${imageName} tray icon image`);
   }
+  // The source PNGs are ~1024px square, which is fine on Linux/Windows but
+  // renders as a massive icon (or gets clipped) in the macOS menu bar, where
+  // status items expect ~22pt. Resize to a menu-bar-friendly size on Darwin.
+  if (process.platform === 'darwin') {
+    return image.resize({width: 22, height: 22});
+  }
   return image;
 }
 

--- a/client/electron/stage_runtime_assets.mjs
+++ b/client/electron/stage_runtime_assets.mjs
@@ -1,0 +1,46 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import fs from 'fs/promises';
+import path from 'path';
+
+import {getRootDir} from '@outline/infrastructure/build/get_root_dir.mjs';
+
+// Runtime assets that the main process loads via `app.getAppPath()` and that
+// `electron-builder` bundles into packaged builds (see `electron-builder.json`
+// `files`). Launching Electron directly against `output/client/electron`
+// bypasses electron-builder, so callers mirror these directories into the
+// launched app path themselves. Without this, code such as the tray icon
+// loader throws `cannot find <name>.png tray icon image`.
+const RUNTIME_ASSET_DIRS = [
+  path.join('client', 'resources', 'tray'),
+  path.join('client', 'www'),
+  path.join('client', 'electron', 'icons'),
+];
+
+/**
+ * Mirrors directories listed in {@link RUNTIME_ASSET_DIRS} from the repo root
+ * into the launched Electron app path so `app.getAppPath()`-relative lookups
+ * resolve the same way they would in a packaged build.
+ *
+ * @param {string} appPath Absolute path to the directory passed to Electron.
+ */
+export async function stageRuntimeAssets(appPath) {
+  for (const relativeDir of RUNTIME_ASSET_DIRS) {
+    const source = path.join(getRootDir(), relativeDir);
+    const destination = path.join(appPath, relativeDir);
+    await fs.mkdir(path.dirname(destination), {recursive: true});
+    await fs.cp(source, destination, {recursive: true});
+  }
+}

--- a/client/electron/start.action.mjs
+++ b/client/electron/start.action.mjs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import fs from 'fs/promises';
 import path from 'path';
 import url from 'url';
 
@@ -21,6 +22,18 @@ import {spawnStream} from '@outline/infrastructure/build/spawn_stream.mjs';
 import electron from 'electron';
 
 import {getBuildParameters} from '../build/get_build_parameters.mjs';
+
+// Runtime assets that the main process loads via `app.getAppPath()` and that
+// `electron-builder` bundles into packaged builds (see `electron-builder.json`
+// `files`). The `start` action launches Electron directly against
+// `output/client/electron`, bypassing electron-builder, so we mirror these
+// directories into the launched app path ourselves. Without this, code such as
+// the tray icon loader throws `cannot find <name>.png tray icon image`.
+const RUNTIME_ASSET_DIRS = [
+  path.join('client', 'resources', 'tray'),
+  path.join('client', 'www'),
+  path.join('client', 'electron', 'icons'),
+];
 
 /**
  * @description Builds and starts the electron application.
@@ -46,12 +59,28 @@ export async function main(...parameters) {
     `--arch=${arch}`
   );
 
+  const appPath = path.join(getRootDir(), 'output', 'client', 'electron');
+  await stageRuntimeAssets(appPath);
+
   process.env.OUTLINE_DEBUG = buildMode === 'debug';
 
-  await spawnStream(
-    electron,
-    path.join(getRootDir(), 'output', 'client', 'electron')
-  );
+  await spawnStream(electron, appPath);
+}
+
+/**
+ * Mirrors directories listed in {@link RUNTIME_ASSET_DIRS} from the repo root
+ * into the launched Electron app path so `app.getAppPath()`-relative lookups
+ * resolve the same way they would in a packaged build.
+ *
+ * @param {string} appPath Absolute path to the directory passed to Electron.
+ */
+async function stageRuntimeAssets(appPath) {
+  for (const relativeDir of RUNTIME_ASSET_DIRS) {
+    const source = path.join(getRootDir(), relativeDir);
+    const destination = path.join(appPath, relativeDir);
+    await fs.mkdir(path.dirname(destination), {recursive: true});
+    await fs.cp(source, destination, {recursive: true});
+  }
 }
 
 if (import.meta.url === url.pathToFileURL(process.argv[1]).href) {

--- a/client/electron/start.action.mjs
+++ b/client/electron/start.action.mjs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import fs from 'fs/promises';
 import path from 'path';
 import url from 'url';
 
@@ -21,19 +20,8 @@ import {runAction} from '@outline/infrastructure/build/run_action.mjs';
 import {spawnStream} from '@outline/infrastructure/build/spawn_stream.mjs';
 import electron from 'electron';
 
+import {stageRuntimeAssets} from './stage_runtime_assets.mjs';
 import {getBuildParameters} from '../build/get_build_parameters.mjs';
-
-// Runtime assets that the main process loads via `app.getAppPath()` and that
-// `electron-builder` bundles into packaged builds (see `electron-builder.json`
-// `files`). The `start` action launches Electron directly against
-// `output/client/electron`, bypassing electron-builder, so we mirror these
-// directories into the launched app path ourselves. Without this, code such as
-// the tray icon loader throws `cannot find <name>.png tray icon image`.
-const RUNTIME_ASSET_DIRS = [
-  path.join('client', 'resources', 'tray'),
-  path.join('client', 'www'),
-  path.join('client', 'electron', 'icons'),
-];
 
 /**
  * @description Builds and starts the electron application.
@@ -65,22 +53,6 @@ export async function main(...parameters) {
   process.env.OUTLINE_DEBUG = buildMode === 'debug';
 
   await spawnStream(electron, appPath);
-}
-
-/**
- * Mirrors directories listed in {@link RUNTIME_ASSET_DIRS} from the repo root
- * into the launched Electron app path so `app.getAppPath()`-relative lookups
- * resolve the same way they would in a packaged build.
- *
- * @param {string} appPath Absolute path to the directory passed to Electron.
- */
-async function stageRuntimeAssets(appPath) {
-  for (const relativeDir of RUNTIME_ASSET_DIRS) {
-    const source = path.join(getRootDir(), relativeDir);
-    const destination = path.join(appPath, relativeDir);
-    await fs.mkdir(path.dirname(destination), {recursive: true});
-    await fs.cp(source, destination, {recursive: true});
-  }
 }
 
 if (import.meta.url === url.pathToFileURL(process.argv[1]).href) {


### PR DESCRIPTION
The 'start' action launches Electron directly against output/client/electron, bypassing the electron-builder packaging pipeline that bundles tray icons, the web app, and platform icons into the app. Mirror those directories into the launched app path so app.getAppPath()-relative lookups resolve the same way they would in a packaged build. Without this, the tray icon loader, web app entry HTML, and Linux window icon all fail to load.

Also resize the tray icon image on macOS, where the source 1024px PNGs render oversized in the menu bar status area (NSStatusItem expects ~22pt).