### PR TITLE
fix(manager): enable DigitalOcean droplet agent at create time

### DIFF
--- a/server_manager/cloud/digitalocean_api.ts
+++ b/server_manager/cloud/digitalocean_api.ts
@@ -149,9 +149,13 @@ export class RestApiSession implements DigitalOceanSession {
           user_data: dropletSpec.installCommand,
           tags: dropletSpec.tags,
           ipv6: true,
-          // We install metrics and droplet agents in the user_data script in order to not delay the droplet readiness.
+          // We install the metrics agent in the user_data script in order to not delay the droplet readiness.
           monitoring: false,
-          with_droplet_agent: false,
+          // Use DigitalOcean's documented default of installing the droplet
+          // agent at create time. Installing it later from the user_data
+          // script (the previous approach) stopped giving working web console
+          // access on droplets created after 2026-03-26 (#2761).
+          with_droplet_agent: true,
         })
           .then(fulfill)
           .catch(e => {

--- a/server_manager/cloud/digitalocean_api.ts
+++ b/server_manager/cloud/digitalocean_api.ts
@@ -151,10 +151,11 @@ export class RestApiSession implements DigitalOceanSession {
           ipv6: true,
           // We install the metrics agent in the user_data script in order to not delay the droplet readiness.
           monitoring: false,
-          // Use DigitalOcean's documented default of installing the droplet
-          // agent at create time. Installing it later from the user_data
-          // script (the previous approach) stopped giving working web console
-          // access on droplets created after 2026-03-26 (#2761).
+          // TODO(laplante): revert
+          // https://github.com/OutlineFoundation/outline-apps/pull/2763
+          // and move agent installation back after droplet creation
+          // once we have a fix for
+          // https://github.com/digitalocean/droplet-agent/issues/224
           with_droplet_agent: true,
         })
           .then(fulfill)

--- a/server_manager/install_scripts/do_install_server.sh
+++ b/server_manager/install_scripts/do_install_server.sh
@@ -195,15 +195,16 @@ done
 # the finish trap in this file will be able to access its error code.
 wait "${install_pid}"
 
-# We could install the agents below in the create droplet request, but they add
+# We could install the metrics agent in the create droplet request, but it adds
 # over a minute of delay to the droplet readiness. Instead, we do it here.
 # Since the server manager looks only for the tags created in the previous
 # step, this does not slow down server creation.
+#
+# Note: the droplet agent used to be installed here too, but that path stopped
+# producing working web-console access on droplets created after 2026-03-26
+# (#2761). It is now installed by DigitalOcean at create time via
+# with_droplet_agent, which is their documented default.
 
 # Install the DigitalOcean Metrics Agent, for improved monitoring:
 # https://docs.digitalocean.com/products/monitoring/how-to/install-agent/
 curl -sSL https://repos.insights.digitalocean.com/install.sh | bash
-
-# Install the DigitalOcean Droplet Agent, for web console integration:
-# https://docs.digitalocean.com/products/droplets/how-to/manage-agent/
-curl -sSL https://repos-droplet.digitalocean.com/install.sh | bash

--- a/server_manager/install_scripts/do_install_server.sh
+++ b/server_manager/install_scripts/do_install_server.sh
@@ -199,11 +199,6 @@ wait "${install_pid}"
 # over a minute of delay to the droplet readiness. Instead, we do it here.
 # Since the server manager looks only for the tags created in the previous
 # step, this does not slow down server creation.
-#
-# Note: the droplet agent used to be installed here too, but that path stopped
-# producing working web-console access on droplets created after 2026-03-26
-# (#2761). It is now installed by DigitalOcean at create time via
-# with_droplet_agent, which is their documented default.
 
 # Install the DigitalOcean Metrics Agent, for improved monitoring:
 # https://docs.digitalocean.com/products/monitoring/how-to/install-agent/


### PR DESCRIPTION
Historically Outline Manager created droplets with `with_droplet_agent: false` and then installing the droplet-agent itself from the user_data script. Some time in late Spring 2026 this stopped producing working web-console access (#2761): the agent installs, but DigitalOcean's console refuses to connect and prompts the user to re-install it.

I'm not sure of the exact cause yet, but it appears to be some change on DO's infrastructure. I've filed https://github.com/digitalocean/droplet-agent/issues/224 against them.

This fix is unideal, since it adds an extra time delay (~minutes) to droplet provisioning time. But it's still better than having broken web console. When DO gets back to us on https://github.com/digitalocean/droplet-agent/issues/224 and we have a better fix I will revert this change.

Fixes #2761 (confirmed via testing by both me and @koyan-testpilot)