### PR TITLE
ci(client): bump iOS Debug Build runner to macos-15

### DIFF
--- a/.github/workflows/build_and_test_debug_client.yml
+++ b/.github/workflows/build_and_test_debug_client.yml
@@ -187,7 +187,7 @@ jobs:
 
   ios_debug_build:
     name: iOS Debug Build
-    runs-on: macos-14
+    runs-on: macos-15
     timeout-minutes: 20
     needs: [web_test, backend_test]
     steps:

--- a/client/config.xml
+++ b/client/config.xml
@@ -72,7 +72,7 @@
 
     <!-- iOS -->
     <platform name="ios">
-        <preference name="deployment-target" value="11.0" />
+        <preference name="deployment-target" value="15.5" />
         <preference name="scheme" value="app" />
         <preference name="hostname" value="localhost" />
         <preference name="DisallowOverscroll" value="true" />

--- a/client/src/cordova/test.action.mjs
+++ b/client/src/cordova/test.action.mjs
@@ -66,7 +66,7 @@ export async function main(...parameters) {
     '-destination',
     outlinePlatform === 'macos'
       ? `platform=macOS,variant=Mac Catalyst,arch=${os.machine()}`
-      : 'platform=iOS Simulator,OS=17.0.1,name=iPhone 15',
+      : 'platform=iOS Simulator,OS=latest,name=iPhone 16',
     '-project',
     path.join(APPLE_ROOT, 'OutlineLib', 'OutlineLib.xcodeproj'),
     '-enableCodeCoverage',


### PR DESCRIPTION
Bump the ios CI to use macos-15 from macos-14. This means both the ios and macos CI now use the same versions.

This means we will now test against latest ios (currently 18) instead of 17. Our minimum supported ios version is 15.5 https://support.getoutline.org/client/getting-started/system-requirements/

The macos-14 image ships Xcode 15.4, whose iOS SDK does not include the Controls framework (ControlWidget, ControlValueProvider, SetValueIntent, @Parameter). macos-15 ships Xcode 16+, which the upcoming iOS 18 Control Center extension needs.

This fixes a CI issue for https://github.com/outlinefoundation/outline-apps/pull/2768
failed job: https://github.com/OutlineFoundation/outline-apps/actions/runs/25771993428/job/75749343397?pr=2768

unrelated cleanup: bump client/config.xml ios version from stale 11.0 to our documented minimum 15.5