### PR TITLE
docs: show UFW commands after setup

### DIFF
--- a/server_manager/install_scripts/install_server.sh
+++ b/server_manager/install_scripts/install_server.sh
@@ -423,6 +423,11 @@ ${FIREWALL_STATUS}
 Make sure to open the following ports on your firewall, router or cloud provider:
 - Management port ${API_PORT}, for TCP
 - Access key port ${ACCESS_KEY_PORT}, for TCP and UDP
+
+If you use UFW, you can allow these ports with:
+  sudo ufw allow ${API_PORT}/tcp
+  sudo ufw allow ${ACCESS_KEY_PORT}/tcp
+  sudo ufw allow ${ACCESS_KEY_PORT}/udp
 "
 }
 


### PR DESCRIPTION
## Summary
- add concrete UFW allow commands to the server setup completion output
- keep the existing generic firewall/router/cloud-provider guidance

Fixes #2772

## Validation
- bash -n server_manager/install_scripts/install_server.sh
- git diff --check

If this PR is squashed or reworked, please preserve author attribution or include: Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>