### PR TITLE
feat(client/windows): add startup toggle

### DIFF
--- a/client/electron/auto_start_on_login_store.ts
+++ b/client/electron/auto_start_on_login_store.ts
@@ -23,9 +23,7 @@ export class AutoStartOnLoginStore {
   private storagePath: string;
 
   constructor(storagePath: string) {
-    if (!fs.existsSync(storagePath)) {
-      fs.mkdirSync(storagePath);
-    }
+    fs.mkdirSync(storagePath, {recursive: true});
     this.storagePath = path.join(storagePath, 'auto_start_on_login_store');
   }
 

--- a/client/electron/auto_start_on_login_store.ts
+++ b/client/electron/auto_start_on_login_store.ts
@@ -1,0 +1,67 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+interface AutoStartOnLoginSettings {
+  enabled: boolean;
+}
+
+export class AutoStartOnLoginStore {
+  private storagePath: string;
+
+  constructor(storagePath: string) {
+    if (!fs.existsSync(storagePath)) {
+      fs.mkdirSync(storagePath);
+    }
+    this.storagePath = path.join(storagePath, 'auto_start_on_login_store');
+  }
+
+  save(enabled: boolean): Promise<void> {
+    const settings: AutoStartOnLoginSettings = {enabled};
+    return new Promise((resolve, reject) => {
+      fs.writeFile(
+        this.storagePath,
+        JSON.stringify(settings),
+        'utf8',
+        error => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve();
+          }
+        }
+      );
+    });
+  }
+
+  load(): Promise<boolean> {
+    return new Promise(resolve => {
+      fs.readFile(this.storagePath, 'utf8', (_error, data) => {
+        if (!data) {
+          resolve(true);
+          return;
+        }
+
+        try {
+          const settings = JSON.parse(data) as AutoStartOnLoginSettings;
+          resolve(settings.enabled !== false);
+        } catch {
+          resolve(true);
+        }
+      });
+    });
+  }
+}

--- a/client/electron/index.ts
+++ b/client/electron/index.ts
@@ -34,6 +34,7 @@ import {
 import {autoUpdater} from 'electron-updater';
 
 import {lookupIp} from './connectivity';
+import {AutoStartOnLoginStore} from './auto_start_on_login_store';
 import {invokeGoMethod} from './go_plugin';
 import {GoVpnTunnel} from './go_vpn_tunnel';
 import {installRoutingServices, RoutingDaemon} from './routing_service';
@@ -62,6 +63,9 @@ const IS_WINDOWS = os.platform() === 'win32';
 // Used for the auto-connect feature. There will be a tunnel in store
 // if the user was connected at shutdown.
 const tunnelStore = new TunnelStore(app.getPath('userData'));
+const autoStartOnLoginStore = new AutoStartOnLoginStore(
+  app.getPath('userData')
+);
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
@@ -87,6 +91,7 @@ const enum Options {
 }
 
 let currentTunnel: VpnTunnel | undefined;
+let autoStartOnLoginEnabled = true;
 
 /**
  * Sentry must be initialized before electron app is ready:
@@ -311,13 +316,37 @@ async function setupAutoLaunch(request: StartRequestJson): Promise<void> {
   try {
     await tunnelStore.save(request);
     if (IS_WINDOWS) {
-      app.setLoginItemSettings({openAtLogin: true, args: [Options.AUTOSTART]});
+      app.setLoginItemSettings({
+        openAtLogin: autoStartOnLoginEnabled,
+        args: autoStartOnLoginEnabled ? [Options.AUTOSTART] : [],
+      });
     }
     // TODO(linux): support auto-launch on Debian. First check whether the Go
     // backend service already restores the tunnel on reboot — if so, no
     // Electron-side auto-launch hook is needed.
   } catch (e) {
     console.error(`Failed to set up auto-launch: ${e.message}`);
+  }
+}
+
+async function setAutoStartOnLoginEnabled(enabled: boolean): Promise<void> {
+  autoStartOnLoginEnabled = enabled;
+  await autoStartOnLoginStore.save(enabled);
+
+  if (!IS_WINDOWS) {
+    return;
+  }
+
+  if (!enabled) {
+    app.setLoginItemSettings({openAtLogin: false});
+    return;
+  }
+
+  try {
+    await tunnelStore.load();
+    app.setLoginItemSettings({openAtLogin: true, args: [Options.AUTOSTART]});
+  } catch {
+    app.setLoginItemSettings({openAtLogin: false});
   }
 }
 
@@ -454,6 +483,10 @@ function main() {
     setupTray();
     // TODO(fortuna): Start the app with the window hidden on auto-start?
     setupWindow();
+    autoStartOnLoginEnabled = await autoStartOnLoginStore.load();
+    if (IS_WINDOWS && !autoStartOnLoginEnabled) {
+      app.setLoginItemSettings({openAtLogin: false});
+    }
 
     if (IS_LINUX) {
       await onVpnStateChanged(setUiTunnelStatus);
@@ -585,6 +618,13 @@ function main() {
       return errors.ErrorCode.UNEXPECTED;
     }
   });
+
+  ipcMain.handle(
+    'outline-ipc-set-auto-start-on-login-enabled',
+    async (_, enabled: boolean) => {
+      await setAutoStartOnLoginEnabled(enabled);
+    }
+  );
 
   // TODO: refactor channel name and namespace to a constant
   ipcMain.on('outline-ipc-quit-app', quitApp);

--- a/client/electron/index.ts
+++ b/client/electron/index.ts
@@ -33,8 +33,8 @@ import {
 } from 'electron';
 import {autoUpdater} from 'electron-updater';
 
-import {lookupIp} from './connectivity';
 import {AutoStartOnLoginStore} from './auto_start_on_login_store';
+import {lookupIp} from './connectivity';
 import {invokeGoMethod} from './go_plugin';
 import {GoVpnTunnel} from './go_vpn_tunnel';
 import {installRoutingServices, RoutingDaemon} from './routing_service';
@@ -337,8 +337,8 @@ async function setupAutoLaunch(request: StartRequestJson): Promise<void> {
 
 async function setAutoStartOnLoginEnabled(enabled: boolean): Promise<void> {
   autoStartOnLoginEnabled = enabled;
-  await autoStartOnLoginStore.save(enabled);
   updateAutoStartOnLoginRegistration();
+  await autoStartOnLoginStore.save(enabled);
 }
 
 async function tearDownAutoLaunch() {

--- a/client/electron/index.ts
+++ b/client/electron/index.ts
@@ -310,17 +310,23 @@ function interceptShadowsocksLink(argv: string[]) {
   }
 }
 
-// Set the app to launch at startup to connect automatically in case of a shutdown while
+function updateAutoStartOnLoginRegistration() {
+  if (!IS_WINDOWS) {
+    return;
+  }
+
+  app.setLoginItemSettings({
+    openAtLogin: autoStartOnLoginEnabled,
+    args: autoStartOnLoginEnabled ? [Options.AUTOSTART] : [],
+  });
+}
+
+// Store the active tunnel so the app can reconnect automatically in case of a shutdown while
 // proxying.
 async function setupAutoLaunch(request: StartRequestJson): Promise<void> {
   try {
     await tunnelStore.save(request);
-    if (IS_WINDOWS) {
-      app.setLoginItemSettings({
-        openAtLogin: autoStartOnLoginEnabled,
-        args: autoStartOnLoginEnabled ? [Options.AUTOSTART] : [],
-      });
-    }
+    updateAutoStartOnLoginRegistration();
     // TODO(linux): support auto-launch on Debian. First check whether the Go
     // backend service already restores the tunnel on reboot — if so, no
     // Electron-side auto-launch hook is needed.
@@ -332,30 +338,13 @@ async function setupAutoLaunch(request: StartRequestJson): Promise<void> {
 async function setAutoStartOnLoginEnabled(enabled: boolean): Promise<void> {
   autoStartOnLoginEnabled = enabled;
   await autoStartOnLoginStore.save(enabled);
-
-  if (!IS_WINDOWS) {
-    return;
-  }
-
-  if (!enabled) {
-    app.setLoginItemSettings({openAtLogin: false});
-    return;
-  }
-
-  try {
-    await tunnelStore.load();
-    app.setLoginItemSettings({openAtLogin: true, args: [Options.AUTOSTART]});
-  } catch {
-    app.setLoginItemSettings({openAtLogin: false});
-  }
+  updateAutoStartOnLoginRegistration();
 }
 
 async function tearDownAutoLaunch() {
   try {
-    if (IS_WINDOWS) {
-      app.setLoginItemSettings({openAtLogin: false});
-    }
     await tunnelStore.clear();
+    updateAutoStartOnLoginRegistration();
   } catch (e) {
     console.error(`Failed to tear down auto-launch: ${e.message}`);
   }
@@ -484,9 +473,7 @@ function main() {
     // TODO(fortuna): Start the app with the window hidden on auto-start?
     setupWindow();
     autoStartOnLoginEnabled = await autoStartOnLoginStore.load();
-    if (IS_WINDOWS && !autoStartOnLoginEnabled) {
-      app.setLoginItemSettings({openAtLogin: false});
-    }
+    updateAutoStartOnLoginRegistration();
 
     if (IS_LINUX) {
       await onVpnStateChanged(setUiTunnelStatus);

--- a/client/electron/index.ts
+++ b/client/electron/index.ts
@@ -92,6 +92,7 @@ const enum Options {
 
 let currentTunnel: VpnTunnel | undefined;
 let autoStartOnLoginEnabled = true;
+let hasAutoLaunchTunnel = false;
 
 /**
  * Sentry must be initialized before electron app is ready:
@@ -315,9 +316,10 @@ function updateAutoStartOnLoginRegistration() {
     return;
   }
 
+  const openAtLogin = autoStartOnLoginEnabled && hasAutoLaunchTunnel;
   app.setLoginItemSettings({
-    openAtLogin: autoStartOnLoginEnabled,
-    args: autoStartOnLoginEnabled ? [Options.AUTOSTART] : [],
+    openAtLogin,
+    args: openAtLogin ? [Options.AUTOSTART] : [],
   });
 }
 
@@ -326,6 +328,7 @@ function updateAutoStartOnLoginRegistration() {
 async function setupAutoLaunch(request: StartRequestJson): Promise<void> {
   try {
     await tunnelStore.save(request);
+    hasAutoLaunchTunnel = true;
     updateAutoStartOnLoginRegistration();
     // TODO(linux): support auto-launch on Debian. First check whether the Go
     // backend service already restores the tunnel on reboot — if so, no
@@ -344,6 +347,7 @@ async function setAutoStartOnLoginEnabled(enabled: boolean): Promise<void> {
 async function tearDownAutoLaunch() {
   try {
     await tunnelStore.clear();
+    hasAutoLaunchTunnel = false;
     updateAutoStartOnLoginRegistration();
   } catch (e) {
     console.error(`Failed to tear down auto-launch: ${e.message}`);
@@ -473,7 +477,6 @@ function main() {
     // TODO(fortuna): Start the app with the window hidden on auto-start?
     setupWindow();
     autoStartOnLoginEnabled = await autoStartOnLoginStore.load();
-    updateAutoStartOnLoginRegistration();
 
     if (IS_LINUX) {
       await onVpnStateChanged(setUiTunnelStatus);
@@ -482,12 +485,15 @@ function main() {
     let requestAtShutdown: StartRequestJson | undefined;
     try {
       requestAtShutdown = await tunnelStore.load();
+      hasAutoLaunchTunnel = true;
     } catch (e) {
       // No tunnel at shutdown, or failure - either way, no need to start.
       // TODO: Instead of quitting, how about creating the system tray icon?
       console.warn('Could not load active tunnel: ', e);
       await tunnelStore.clear();
+      hasAutoLaunchTunnel = false;
     }
+    updateAutoStartOnLoginRegistration();
     if (requestAtShutdown) {
       console.info(
         `was connected at shutdown, reconnecting to ${requestAtShutdown.id}`

--- a/client/electron/index.ts
+++ b/client/electron/index.ts
@@ -609,6 +609,12 @@ function main() {
   ipcMain.handle(
     'outline-ipc-set-auto-start-on-login-enabled',
     async (_, enabled: boolean) => {
+      if (typeof enabled !== 'boolean') {
+        console.error(
+          `outline-ipc-set-auto-start-on-login-enabled: expected boolean, got ${typeof enabled}`
+        );
+        return;
+      }
       await setAutoStartOnLoginEnabled(enabled);
     }
   );

--- a/client/resources/original_messages.json
+++ b/client/resources/original_messages.json
@@ -688,8 +688,8 @@
     "message": "Outline"
   },
   "settings_auto_start_on_login": {
-    "description": "The label for a setting that controls whether the Outline Client automatically starts when the user logs in.",
-    "message": "Run Outline on startup"
+    "description": "The label for a setting that controls whether Outline automatically starts after device restart to reconnect to the last connected server.",
+    "message": "Stay connected after restart"
   },
   "settings_page_title": {
     "description": "The title of a page for changing application settings.",

--- a/client/resources/original_messages.json
+++ b/client/resources/original_messages.json
@@ -687,6 +687,14 @@
     "description": "The title of the main page of the application, showing the application's title (Outline). Outline is the product name and can be found in the translation glossary.",
     "message": "Outline"
   },
+  "settings_auto_start_on_login": {
+    "description": "The label for a setting that controls whether the Outline Client automatically starts when the user logs in.",
+    "message": "Run Outline on startup"
+  },
+  "settings_page_title": {
+    "description": "The title of a page for changing application settings.",
+    "message": "Settings"
+  },
   "split_confirm_dialog_content": {
     "description": "The body text of a dialog box asking the user to confirm connecting with limited protection (split tunneling).",
     "message": "This key offers limited protection when connecting to the open internet. Outline will bypass the VPN (proxy) server in certain cases.<ul><li>For some connections, Outline will connect directly to the internet.</li><li>For some connections, Outline will use an alternative method to make it hard for others to see what you connect to.</li></ul>This key may help you connect to the open internet if your VPN access key is not successfully connecting.<br><br>To learn more, contact the person who gave you this access key."

--- a/client/web/app/app.ts
+++ b/client/web/app/app.ts
@@ -647,8 +647,12 @@ export class App {
   }
 
   private syncAutoStartOnLoginSetting() {
-    this.autoStartOnLoginSettings
-      ?.setEnabled(this.isAutoStartOnLoginEnabled())
+    if (!this.autoStartOnLoginSettings) {
+      return;
+    }
+
+    void this.autoStartOnLoginSettings
+      .setEnabled(this.isAutoStartOnLoginEnabled())
       .catch(e => {
         console.error('failed to update auto-start setting', e);
         this.showLocalizedError(e);

--- a/client/web/app/app.ts
+++ b/client/web/app/app.ts
@@ -18,6 +18,7 @@ import {OperationTimedOut} from '@outline/infrastructure/timeout_promise';
 import {Clipboard} from './clipboard';
 import {EnvironmentVariables} from './environment';
 import * as config from './outline_server_repository/config';
+import {AutoStartOnLoginSettings} from './platform';
 import {Settings, SettingsKey, Appearance} from './settings';
 import {Updater} from './updater';
 import {UrlInterceptor} from './url_interceptor';
@@ -104,6 +105,7 @@ export class App {
     environmentVars: EnvironmentVariables,
     private updater: Updater,
     private installer: VpnInstaller,
+    private autoStartOnLoginSettings: AutoStartOnLoginSettings | undefined,
     private quitApplication: () => void,
     document = window.document
   ) {
@@ -201,6 +203,16 @@ export class App {
           this.settings.set(SettingsKey.APPEARANCE, event.detail.appearance);
           this.setAppearance(event.detail.appearance);
         }
+      );
+    }
+
+    if (this.autoStartOnLoginSettings) {
+      this.rootEl.showSettingsView = true;
+      this.rootEl.autoStartOnLoginEnabled = this.isAutoStartOnLoginEnabled();
+      this.syncAutoStartOnLoginSetting();
+      this.rootEl.addEventListener(
+        'SetAutoStartOnLoginRequested',
+        this.setAutoStartOnLogin.bind(this)
       );
     }
 
@@ -605,6 +617,10 @@ export class App {
   }
 
   private maybeShowAutoConnectDialog() {
+    if (!this.isAutoStartOnLoginEnabled()) {
+      return;
+    }
+
     let dismissed = false;
     try {
       dismissed =
@@ -617,6 +633,26 @@ export class App {
     if (!dismissed) {
       this.rootEl.$.autoConnectDialog.open = true;
     }
+  }
+
+  private isAutoStartOnLoginEnabled() {
+    return this.settings.get(SettingsKey.AUTO_START_ON_LOGIN) !== 'false';
+  }
+
+  private setAutoStartOnLogin(event: CustomEvent) {
+    const enabled = event.detail.enabled;
+    this.settings.set(SettingsKey.AUTO_START_ON_LOGIN, String(enabled));
+    this.rootEl.autoStartOnLoginEnabled = enabled;
+    this.syncAutoStartOnLoginSetting();
+  }
+
+  private syncAutoStartOnLoginSetting() {
+    this.autoStartOnLoginSettings
+      ?.setEnabled(this.isAutoStartOnLoginEnabled())
+      .catch(e => {
+        console.error('failed to update auto-start setting', e);
+        this.showLocalizedError(e);
+      });
   }
 
   private autoConnectDialogDismissed() {

--- a/client/web/app/main.cordova.ts
+++ b/client/web/app/main.cordova.ts
@@ -127,6 +127,10 @@ class CordovaPlatform implements OutlinePlatform {
     return new NoOpVpnInstaller();
   }
 
+  getAutoStartOnLoginSettings(): undefined {
+    return undefined;
+  }
+
   quitApplication() {
     // Only used in macOS because menu bar apps provide no alternative way of quitting.
     cordova.exec(

--- a/client/web/app/main.electron.ts
+++ b/client/web/app/main.electron.ts
@@ -24,6 +24,7 @@ import {getLocalizationFunction, main} from './main';
 import {installDefaultMethodChannel, MethodChannel} from './method_channel';
 import {VpnApi} from './outline_server_repository/vpn';
 import {ElectronVpnApi} from './outline_server_repository/vpn.electron';
+import {AutoStartOnLoginSettings} from './platform';
 import {AbstractUpdater} from './updater';
 import {UrlInterceptor} from './url_interceptor';
 import {VpnInstaller} from './vpn_installer';
@@ -105,6 +106,15 @@ class ElectronVpnInstaller implements VpnInstaller {
   }
 }
 
+class ElectronAutoStartOnLoginSettings implements AutoStartOnLoginSettings {
+  async setEnabled(enabled: boolean): Promise<void> {
+    await window.electron.methodChannel.invoke(
+      'set-auto-start-on-login-enabled',
+      enabled
+    );
+  }
+}
+
 class ElectronErrorReporter implements OutlineErrorReporter {
   constructor() {
     // parameters are initialized in main process
@@ -155,5 +165,7 @@ main({
   getErrorReporter: _ => new ElectronErrorReporter(),
   getUpdater: () => new ElectronUpdater(),
   getVpnServiceInstaller: () => new ElectronVpnInstaller(),
+  getAutoStartOnLoginSettings: () =>
+    isWindows ? new ElectronAutoStartOnLoginSettings() : undefined,
   quitApplication: () => window.electron.methodChannel.send('quit-app'),
 });

--- a/client/web/app/main.ts
+++ b/client/web/app/main.ts
@@ -134,6 +134,7 @@ export function main(platform: OutlinePlatform) {
         environmentVars,
         platform.getUpdater(),
         platform.getVpnServiceInstaller(),
+        platform.getAutoStartOnLoginSettings(),
         platform.quitApplication
       );
     },

--- a/client/web/app/platform.ts
+++ b/client/web/app/platform.ts
@@ -20,6 +20,10 @@ import {UrlInterceptor} from './url_interceptor';
 import {VpnInstaller} from './vpn_installer';
 import {OutlineErrorReporter} from '../shared/error_reporter';
 
+export interface AutoStartOnLoginSettings {
+  setEnabled(enabled: boolean): Promise<void>;
+}
+
 // Provides platform-specific dependencies.
 // TODO(fortuna): pick platform-specific implementations at build time instead.
 export interface OutlinePlatform {
@@ -34,6 +38,8 @@ export interface OutlinePlatform {
   getUpdater(): Updater;
 
   getVpnServiceInstaller(): VpnInstaller;
+
+  getAutoStartOnLoginSettings(): AutoStartOnLoginSettings | undefined;
 
   quitApplication(): void;
 }

--- a/client/web/app/settings.ts
+++ b/client/web/app/settings.ts
@@ -22,6 +22,7 @@ export enum SettingsKey {
   AUTO_CONNECT_DIALOG_DISMISSED = 'auto-connect-dialog-dismissed',
   PRIVACY_ACK = 'privacy-ack',
   APPEARANCE = 'appearance',
+  AUTO_START_ON_LOGIN = 'auto-start-on-login',
 }
 
 // Theme options

--- a/client/web/messages/en-GB.json
+++ b/client/web/messages/en-GB.json
@@ -108,7 +108,7 @@
   "server-rename-complete": "Server renamed",
   "servers-menu-item": "Servers",
   "servers-page-title": "Outline",
-  "settings-auto-start-on-login": "Run Outline on startup",
+  "settings-auto-start-on-login": "Stay connected after restart",
   "settings-page-title": "Settings",
   "submit": "Submit",
   "submitting": "Submitting…",

--- a/client/web/messages/en-GB.json
+++ b/client/web/messages/en-GB.json
@@ -108,6 +108,8 @@
   "server-rename-complete": "Server renamed",
   "servers-menu-item": "Servers",
   "servers-page-title": "Outline",
+  "settings-auto-start-on-login": "Run Outline on startup",
+  "settings-page-title": "Settings",
   "submit": "Submit",
   "submitting": "Submitting…",
   "support-form-access-key-source": "Where did you get your access key?",

--- a/client/web/messages/en.json
+++ b/client/web/messages/en.json
@@ -134,7 +134,7 @@
   "server-split-tunneling-info-dialog-title": "Limited Protection: Split Tunneling Information",
   "servers-menu-item": "Servers",
   "servers-page-title": "Outline",
-  "settings-auto-start-on-login": "Run Outline on startup",
+  "settings-auto-start-on-login": "Stay connected after restart",
   "settings-page-title": "Settings",
   "split-confirm-dialog-content": "This key offers limited protection when connecting to the open internet. Outline will bypass the VPN (proxy) server in certain cases.<ul><li>For some connections, Outline will connect directly to the internet.</li><li>For some connections, Outline will use an alternative method to make it hard for others to see what you connect to.</li></ul>This key may help you connect to the open internet if your VPN access key is not successfully connecting.<br><br>To learn more, contact the person who gave you this access key.",
   "split-confirm-dialog-title": "Connect with Limited Protection?",

--- a/client/web/messages/en.json
+++ b/client/web/messages/en.json
@@ -134,6 +134,8 @@
   "server-split-tunneling-info-dialog-title": "Limited Protection: Split Tunneling Information",
   "servers-menu-item": "Servers",
   "servers-page-title": "Outline",
+  "settings-auto-start-on-login": "Run Outline on startup",
+  "settings-page-title": "Settings",
   "split-confirm-dialog-content": "This key offers limited protection when connecting to the open internet. Outline will bypass the VPN (proxy) server in certain cases.<ul><li>For some connections, Outline will connect directly to the internet.</li><li>For some connections, Outline will use an alternative method to make it hard for others to see what you connect to.</li></ul>This key may help you connect to the open internet if your VPN access key is not successfully connecting.<br><br>To learn more, contact the person who gave you this access key.",
   "split-confirm-dialog-title": "Connect with Limited Protection?",
   "submit": "Submit",

--- a/client/web/ui_components/app-root.js
+++ b/client/web/ui_components/app-root.js
@@ -65,6 +65,8 @@ import '../views/root_view/root_navigation';
 // eslint-disable-next-line n/no-missing-import
 import '../views/appearance_view';
 // eslint-disable-next-line n/no-missing-import
+import '../views/settings_view';
+// eslint-disable-next-line n/no-missing-import
 import * as i18n from '@outline/infrastructure/i18n';
 import {AppLocalizeBehavior} from '@polymer/app-localize-behavior/app-localize-behavior.js';
 import {PaperMenuButton} from '@polymer/paper-menu-button/paper-menu-button.js';
@@ -364,6 +366,12 @@ export class AppRoot extends mixinBehaviors(
             selected-appearance="[[selectedAppearance]]"
             localize="[[localize]]"
           ></appearance-view>
+          <settings-view
+            name="settings"
+            id="settingsView"
+            auto-start-on-login-enabled="[[autoStartOnLoginEnabled]]"
+            localize="[[localize]]"
+          ></settings-view>
         </iron-pages>
       </app-header-layout>
 
@@ -373,6 +381,7 @@ export class AppRoot extends mixinBehaviors(
         show-quit="[[shouldShowQuitButton]]"
         data-collection-page-url="https://getoutline.org/policies/data-collection"
         show-appearance-view="[[showAppearanceView]]"
+        show-settings-view="[[showSettingsView]]"
       ></root-navigation>
 
       <add-access-key-dialog
@@ -594,6 +603,14 @@ export class AppRoot extends mixinBehaviors(
       showAppearanceView: {
         type: Boolean,
         value: false,
+      },
+      showSettingsView: {
+        type: Boolean,
+        value: false,
+      },
+      autoStartOnLoginEnabled: {
+        type: Boolean,
+        value: true,
       },
       selectedAppearance: {
         type: String,

--- a/client/web/views/root_view/root_navigation/index.ts
+++ b/client/web/views/root_view/root_navigation/index.ts
@@ -27,6 +27,7 @@ export class RootNavigation extends LitElement {
   @property({type: String}) align: 'left' | 'right';
   @property({type: String}) dataCollectionPageUrl: string;
   @property({type: Boolean}) showAppearanceView: boolean = false;
+  @property({type: Boolean}) showSettingsView: boolean = false;
 
   static styles = css`
     :host {
@@ -246,6 +247,15 @@ export class RootNavigation extends LitElement {
                   <md-ripple></md-ripple>
                   <md-icon slot="start">brightness_medium</md-icon>
                   ${this.localize('appearance-page-title')}
+                </md-list-item>
+              `
+            : nothing}
+          ${this.showSettingsView
+            ? html`
+                <md-list-item @click=${() => this.changePage('settings')}>
+                  <md-ripple></md-ripple>
+                  <md-icon slot="start">settings</md-icon>
+                  ${this.localize('settings-page-title')}
                 </md-list-item>
               `
             : nothing}

--- a/client/web/views/settings_view/index.ts
+++ b/client/web/views/settings_view/index.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 The Outline Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {LitElement, html, css} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
+
+@customElement('settings-view')
+export class SettingsView extends LitElement {
+  @property({type: Boolean}) autoStartOnLoginEnabled = true;
+  @property({type: Object}) localize: (key: string) => string = msg => msg;
+
+  static styles = css`
+    :host {
+      background-color: var(--outline-background);
+      color: var(--outline-text-color);
+      display: block;
+      height: 100%;
+      width: 100%;
+    }
+
+    md-list {
+      --md-list-container-color: var(--outline-card-background);
+      background-color: var(--outline-background);
+      color: var(--outline-text-color);
+      padding: 8px 0;
+    }
+
+    md-list-item {
+      --md-list-item-headline-color: var(--outline-text-color);
+      --md-list-item-label-text-color: var(--outline-text-color);
+      --md-list-item-supporting-text-color: var(--outline-text-color);
+      color: var(--outline-text-color);
+    }
+
+    md-icon {
+      color: var(--outline-icon-color);
+      font-size: 24px;
+    }
+  `;
+
+  render() {
+    return html`
+      <md-list>
+        <md-list-item>
+          <md-icon slot="start">power_settings_new</md-icon>
+          <span>${this.localize('settings-auto-start-on-login')}</span>
+          <md-switch
+            slot="end"
+            ?selected=${this.autoStartOnLoginEnabled}
+            @change=${this.handleAutoStartChange}
+          ></md-switch>
+        </md-list-item>
+      </md-list>
+    `;
+  }
+
+  private handleAutoStartChange(event: Event) {
+    const enabled = (event.target as HTMLInputElement & {selected: boolean})
+      .selected;
+    this.autoStartOnLoginEnabled = enabled;
+    this.dispatchEvent(
+      new CustomEvent('SetAutoStartOnLoginRequested', {
+        bubbles: true,
+        composed: true,
+        detail: {enabled},
+      })
+    );
+  }
+}


### PR DESCRIPTION
Summary:
- Add a Windows-only Settings page entry, `Stay connected after restart`, for opting out of Outline's existing reconnect-after-restart startup behavior.
- Preserve the old simple model: Windows Startup Apps registration is tied to a saved active tunnel, so disconnecting still removes the startup entry.
- Persist the preference in Electron and use it as an additional gate when updating Windows login item settings.
- Keep the preference enabled by default to preserve existing auto-reconnect behavior for users who do not change the setting.

Behavior:

| Setting | VPN state | Windows Startup Apps behavior |
|---|---|---|
| Stay connected after restart: ON | connected / saved for reconnect | Outline is registered to start on login and reconnect |
| Stay connected after restart: ON | disconnected | Outline is not registered to start on login |
| Stay connected after restart: OFF | connected or disconnected | Outline is not registered to start on login |

Validation:
- git diff --check
- npx eslint client/electron/index.ts client/web/app/app.ts
- npm run action client/electron/build windows
- Manual Windows test on Windows 11: with the setting ON and VPN connected, restarted and confirmed Outline launched and attempted reconnect; with the setting OFF while VPN was connected, restarted and confirmed Outline did not launch or reconnect.

Fixes #2559