### PR TITLE
refactor(client): make electron-builder.json arch-agnostic

### DIFF
--- a/.github/workflows/build_and_test_debug_client.yml
+++ b/.github/workflows/build_and_test_debug_client.yml
@@ -75,8 +75,8 @@ jobs:
       - name: Test Go Backend
         run: go test -race -bench=. -benchtime=100ms ./client/...
 
-  linux_amd64_debug_build:
-    name: Linux amd64 Debug Build
+  linux_x64_debug_build:
+    name: Linux x64 Debug Build
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     needs: [web_test, backend_test]
@@ -106,7 +106,7 @@ jobs:
           use-cache: false
 
       - name: Build Linux Client
-        run: npm run action client/electron/build linux -- --arch amd64
+        run: npm run action client/electron/build linux -- --arch x64
 
   linux_arm64_debug_build:
     name: Linux arm64 Debug Build

--- a/client/build/get_build_parameters.mjs
+++ b/client/build/get_build_parameters.mjs
@@ -24,11 +24,13 @@ const VALID_PLATFORMS = [
 ];
 const VALID_BUILD_MODES = ['debug', 'release'];
 
-// --arch values accepted per platform. Uses electron-builder's arch
-// vocabulary; downstream (the Taskfile, our output/client/<platform>-<arch>
-// directories) uses Go arch names — translated where needed via
-// ELECTRON_ARCH_TO_GO_ARCH in build.action.mjs. Platforms not in this map
-// don't accept --arch.
+// --arch uses electron-builder's arch vocabulary. The Taskfile and our
+// output/client/<platform>-<arch> directories use Go arch names, so we also
+// return the corresponding Go name from this map.
+const ELECTRON_ARCH_TO_GO_ARCH = {x64: 'amd64', arm64: 'arm64', ia32: '386'};
+
+// --arch values accepted per platform. Platforms not in this map don't
+// accept --arch.
 const VALID_ARCHITECTURES_BY_PLATFORM = {
   linux: ['x64', 'arm64'],
   windows: ['ia32', 'arm64'],
@@ -90,5 +92,6 @@ export function getBuildParameters(cliArguments) {
     sentryDsn,
     buildNumber: Math.floor(Date.now() / MS_PER_HOUR),
     arch,
+    goArch: ELECTRON_ARCH_TO_GO_ARCH[arch],
   };
 }

--- a/client/build/get_build_parameters.mjs
+++ b/client/build/get_build_parameters.mjs
@@ -24,12 +24,13 @@ const VALID_PLATFORMS = [
 ];
 const VALID_BUILD_MODES = ['debug', 'release'];
 
-// --arch values accepted per platform. linux uses Go arch names (matches our
-// output/client/linux-<arch> directories); windows uses electron-builder's
-// names (ia32, arm64) — they map back to Go names downstream where needed.
-// Platforms not in this map don't accept --arch.
+// --arch values accepted per platform. Uses electron-builder's arch
+// vocabulary; downstream (the Taskfile, our output/client/<platform>-<arch>
+// directories) uses Go arch names — translated where needed via
+// ELECTRON_ARCH_TO_GO_ARCH in build.action.mjs. Platforms not in this map
+// don't accept --arch.
 const VALID_ARCHITECTURES_BY_PLATFORM = {
-  linux: ['amd64', 'arm64'],
+  linux: ['x64', 'arm64'],
   windows: ['ia32', 'arm64'],
 };
 

--- a/client/electron/build.action.mjs
+++ b/client/electron/build.action.mjs
@@ -25,11 +25,6 @@ import {getBuildParameters} from '../build/get_build_parameters.mjs';
 
 const ELECTRON_BUILD_DIR = 'output';
 
-// --arch and electron-builder use electron-style arch names (x64, arm64,
-// ia32). The Taskfile and our output/client/<platform>-<arch> directories
-// use Go-style names. Translate at the boundary.
-const ELECTRON_ARCH_TO_GO_ARCH = {x64: 'amd64', arm64: 'arm64', ia32: '386'};
-
 // Per-platform build description. electron-builder.json holds only the
 // arch-independent config; everything that depends on the requested
 // architecture is filled in from this table at build time. `archs` is the
@@ -55,7 +50,7 @@ const ELECTRON_PLATFORMS = {
 };
 
 export async function main(...parameters) {
-  const {platform, buildMode, versionName, arch} =
+  const {platform, buildMode, versionName, arch, goArch} =
     getBuildParameters(parameters);
   const {autoUpdateProvider = 'generic', autoUpdateUrl} = minimist(parameters);
 
@@ -104,7 +99,6 @@ export async function main(...parameters) {
     )
   );
 
-  const goArch = ELECTRON_ARCH_TO_GO_ARCH[arch];
   const binaryDir = `output/client/${platform}-${goArch}`;
 
   // Keep the Go-built binaries outside the asar archive so they're loadable

--- a/client/electron/build.action.mjs
+++ b/client/electron/build.action.mjs
@@ -24,13 +24,32 @@ import minimist from 'minimist';
 import {getBuildParameters} from '../build/get_build_parameters.mjs';
 
 const ELECTRON_BUILD_DIR = 'output';
-const ELECTRON_PLATFORMS = ['linux', 'windows'];
 
-// Maps the Go-style architecture names used throughout the build to the
-// architecture names that electron-builder expects in target.arch.
-const GO_ARCH_TO_ELECTRON_ARCH = {
-  amd64: 'x64',
-  arm64: 'arm64',
+// --arch and electron-builder use electron-style arch names (x64, arm64,
+// ia32). The Taskfile and our output/client/<platform>-<arch> directories
+// use Go-style names. Translate at the boundary.
+const ELECTRON_ARCH_TO_GO_ARCH = {x64: 'amd64', arm64: 'arm64', ia32: '386'};
+
+// Per-platform build description. electron-builder.json holds only the
+// arch-independent config; everything that depends on the requested
+// architecture is filled in from this table at build time. `archs` is the
+// list of values accepted via --arch.
+const ELECTRON_PLATFORMS = {
+  linux: {
+    builderKey: 'linux',
+    archs: ['x64', 'arm64'],
+    targetFormats: ['deb'],
+    binaryFiles: ['libbackend.so', 'tun2socks'],
+    // Non-binary files to include in the package alongside the Go output.
+    extraPackageFiles: ['client/electron/icons/png'],
+  },
+  windows: {
+    builderKey: 'win',
+    archs: ['ia32', 'arm64'],
+    targetFormats: ['nsis'],
+    binaryFiles: ['backend.dll', 'tun2socks.exe'],
+    extraPackageFiles: [],
+  },
 };
 
 export async function main(...parameters) {
@@ -38,9 +57,18 @@ export async function main(...parameters) {
     getBuildParameters(parameters);
   const {autoUpdateProvider = 'generic', autoUpdateUrl} = minimist(parameters);
 
-  if (!ELECTRON_PLATFORMS.includes(platform)) {
+  const platformConfig = ELECTRON_PLATFORMS[platform];
+  if (!platformConfig) {
     throw new TypeError(
-      `The platform "${platform}" is not a valid Electron platform. It must be one of: ${ELECTRON_PLATFORMS.join(
+      `The platform "${platform}" is not a valid Electron platform. It must be one of: ${Object.keys(
+        ELECTRON_PLATFORMS
+      ).join(', ')}.`
+    );
+  }
+
+  if (!arch || !platformConfig.archs.includes(arch)) {
+    throw new TypeError(
+      `Electron ${platform} builds require --arch to be one of: ${platformConfig.archs.join(
         ', '
       )}.`
     );
@@ -74,38 +102,21 @@ export async function main(...parameters) {
     )
   );
 
-  // Retarget the bundled binaries to the requested architecture. The default
-  // config references linux-amd64 / windows-386; remap to <platform>-<arch>
-  // when building for a different arch (e.g. arm64). Also rewrite the target
-  // arch in the platform-specific config so electron-builder packages the
-  // matching artifact.
-  if (platform === 'linux') {
-    const goArch = arch || 'amd64';
-    const electronArch = GO_ARCH_TO_ELECTRON_ARCH[goArch];
-    if (goArch !== 'amd64') {
-      const remap = value =>
-        typeof value === 'string'
-          ? value.replace('linux-amd64', `linux-${goArch}`)
-          : value;
-      electronConfig.asarUnpack = electronConfig.asarUnpack.map(remap);
-      electronConfig.linux.files = electronConfig.linux.files.map(remap);
-    }
-    electronConfig.linux.target = electronConfig.linux.target.map(t => ({
-      ...t,
-      arch: electronArch,
-    }));
-  } else if (platform === 'windows' && arch === 'arm64') {
-    const remap = value =>
-      typeof value === 'string'
-        ? value.replace('windows-386', 'windows-arm64')
-        : value;
-    electronConfig.asarUnpack = electronConfig.asarUnpack.map(remap);
-    electronConfig.win.files = electronConfig.win.files.map(remap);
-    electronConfig.win.target = electronConfig.win.target.map(t => ({
-      ...t,
-      arch: 'arm64',
-    }));
-  }
+  const goArch = ELECTRON_ARCH_TO_GO_ARCH[arch];
+  const binaryDir = `output/client/${platform}-${goArch}`;
+
+  // Keep the Go-built binaries outside the asar archive so they're loadable
+  // at runtime (CGo .so / .dll can't be loaded from inside asar).
+  electronConfig.asarUnpack = platformConfig.binaryFiles.map(
+    f => `${binaryDir}/${f}`
+  );
+  electronConfig[platformConfig.builderKey].files = [
+    ...platformConfig.extraPackageFiles,
+    binaryDir,
+    `!${binaryDir}/*.h`,
+  ];
+  electronConfig[platformConfig.builderKey].target =
+    platformConfig.targetFormats.map(target => ({arch, target}));
 
   // build electron binary
   await electron.build({

--- a/client/electron/build.action.mjs
+++ b/client/electron/build.action.mjs
@@ -39,6 +39,7 @@ const ELECTRON_PLATFORMS = {
     builderKey: 'linux',
     archs: ['x64', 'arm64'],
     targetFormats: ['deb'],
+    // Binary files to keep outside the asar archive so they can be loaded at runtime.
     binaryFiles: ['libbackend.so', 'tun2socks'],
     // Non-binary files to include in the package alongside the Go output.
     extraPackageFiles: ['client/electron/icons/png'],
@@ -47,6 +48,7 @@ const ELECTRON_PLATFORMS = {
     builderKey: 'win',
     archs: ['ia32', 'arm64'],
     targetFormats: ['nsis'],
+    // Binary files to keep outside the asar archive so they can be loaded at runtime.
     binaryFiles: ['backend.dll', 'tun2socks.exe'],
     extraPackageFiles: [],
   },

--- a/client/electron/electron-builder.json
+++ b/client/electron/electron-builder.json
@@ -1,12 +1,6 @@
 {
   "productName": "Outline",
   "artifactName": "Outline-Client-${arch}.${ext}",
-  "asarUnpack": [
-    "output/client/linux-amd64/libbackend.so",
-    "output/client/linux-amd64/tun2socks",
-    "output/client/windows-386/backend.dll",
-    "output/client/windows-386/tun2socks.exe"
-  ],
   "directories": {
     "buildResources": "output/client/electron",
     "output": "output/client/electron/build"
@@ -34,39 +28,18 @@
   "linux": {
     "category": "Network",
     "executableName": "Outline",
-    "files": [
-      "client/electron/icons/png",
-      "output/client/linux-amd64",
-      "!output/client/linux-amd64/*.h"
-    ],
     "icon": "client/electron/icons/png",
-    "maintainer": "Outline Foundation",
-    "target": [
-      {
-        "arch": "x64",
-        "target": "deb"
-      }
-    ]
+    "maintainer": "Outline Foundation"
   },
   "nsis": {
     "include": "client/electron/custom_install_steps.nsh",
     "perMachine": true
   },
   "win": {
-    "files": [
-      "output/client/windows-386",
-      "!output/client/windows-386/*.h"
-    ],
     "icon": "client/electron/icons/win/icon.ico",
     "sign": "client/electron/windows/electron_builder_signing_plugin.cjs",
     "signingHashAlgorithms": [
       "sha256"
-    ],
-    "target": [
-      {
-        "arch": "ia32",
-        "target": "nsis"
-      }
     ]
   }
 }

--- a/client/go/build.action.mjs
+++ b/client/go/build.action.mjs
@@ -18,9 +18,8 @@ import {spawnStream} from '@outline/infrastructure/build/spawn_stream.mjs';
 
 import {getBuildParameters} from '../build/get_build_parameters.mjs';
 
-// electron-builder uses 'ia32' for the 32-bit x86 target; the Go toolchain
-// and our Taskfile call the same arch '386'. Translate at the build boundary.
-const ELECTRON_ARCH_TO_GO_ARCH = {ia32: '386'};
+// --arch uses electron-builder arch names; the Taskfile uses Go arch names.
+const ELECTRON_ARCH_TO_GO_ARCH = {x64: 'amd64', arm64: 'arm64', ia32: '386'};
 
 /**
  * @description Builds the tun2socks library for the specified platform.

--- a/client/go/build.action.mjs
+++ b/client/go/build.action.mjs
@@ -18,18 +18,13 @@ import {spawnStream} from '@outline/infrastructure/build/spawn_stream.mjs';
 
 import {getBuildParameters} from '../build/get_build_parameters.mjs';
 
-// --arch uses electron-builder arch names; the Taskfile uses Go arch names.
-const ELECTRON_ARCH_TO_GO_ARCH = {x64: 'amd64', arm64: 'arm64', ia32: '386'};
-
 /**
  * @description Builds the tun2socks library for the specified platform.
  *
  * @param {string[]} parameters
  */
 export async function main(...parameters) {
-  const {platform: targetPlatform, arch: targetArch} =
-    getBuildParameters(parameters);
-  const goArch = ELECTRON_ARCH_TO_GO_ARCH[targetArch] ?? targetArch;
+  const {platform: targetPlatform, goArch} = getBuildParameters(parameters);
   const targetName = goArch ? `${targetPlatform}:${goArch}` : targetPlatform;
   await spawnStream(
     'go',


### PR DESCRIPTION
Build refactoring following https://github.com/OutlineFoundation/outline-apps/pull/2776 (linux) and https://github.com/OutlineFoundation/outline-apps/pull/2778 (windows) to simplify the electron build and do away with some complicated path/file rewriting. Electron and Go use different names for architectures and it was complicating things.

If you'd like to review all 3 changes together you can see them here: [diff](https://github.com/OutlineFoundation/outline-apps/compare/electron-builder-json-skeleton?expand=1)

Tested:
- built all 4 platform/arch combos
- installed and tested arm64 builds on linux/windows
- I'm not able to test this on non-arm64 platforms, but it seems unlikely that the changes here would break those platforms but not break arm64.