### PR TITLE
fix(manager): use #!/bin/sh in DO user_data so droplet_agent flag is set

### DIFF
--- a/server_manager/cloud/digitalocean_api.ts
+++ b/server_manager/cloud/digitalocean_api.ts
@@ -149,14 +149,9 @@ export class RestApiSession implements DigitalOceanSession {
           user_data: dropletSpec.installCommand,
           tags: dropletSpec.tags,
           ipv6: true,
-          // We install the metrics agent in the user_data script in order to not delay the droplet readiness.
+          // We install metrics and droplet agents in the user_data script in order to not delay the droplet readiness.
           monitoring: false,
-          // TODO(laplante): revert
-          // https://github.com/OutlineFoundation/outline-apps/pull/2763
-          // and move agent installation back after droplet creation
-          // once we have a fix for
-          // https://github.com/digitalocean/droplet-agent/issues/224
-          with_droplet_agent: true,
+          with_droplet_agent: false,
         })
           .then(fulfill)
           .catch(e => {

--- a/server_manager/install_scripts/do_install_server.sh
+++ b/server_manager/install_scripts/do_install_server.sh
@@ -195,7 +195,7 @@ done
 # the finish trap in this file will be able to access its error code.
 wait "${install_pid}"
 
-# We could install the metrics agent in the create droplet request, but it adds
+# We could install the agents below in the create droplet request, but they add
 # over a minute of delay to the droplet readiness. Instead, we do it here.
 # Since the server manager looks only for the tags created in the previous
 # step, this does not slow down server creation.
@@ -203,3 +203,7 @@ wait "${install_pid}"
 # Install the DigitalOcean Metrics Agent, for improved monitoring:
 # https://docs.digitalocean.com/products/monitoring/how-to/install-agent/
 curl -sSL https://repos.insights.digitalocean.com/install.sh | bash
+
+# Install the DigitalOcean Droplet Agent, for web console integration:
+# https://docs.digitalocean.com/products/droplets/how-to/manage-agent/
+curl -sSL https://repos-droplet.digitalocean.com/install.sh | bash

--- a/server_manager/www/digitalocean_account.ts
+++ b/server_manager/www/digitalocean_account.ts
@@ -194,8 +194,13 @@ function getInstallScript(
   shadowboxSettings: ShadowboxSettings
 ): string {
   const sanitizedAccessToken = sanitizeDigitalOceanToken(accessToken);
+  // Must be `#!/bin/sh`: with anything else, DigitalOcean doesn't add
+  // `droplet_agent` to the droplet's features at create time and the
+  // web console refuses to connect.
+  // See https://github.com/digitalocean/droplet-agent/issues/224.
   return (
-    '#!/bin/bash -eu\n' +
+    '#!/bin/sh\n' +
+    'set -eu\n' +
     `export DO_ACCESS_TOKEN='${sanitizedAccessToken}'\n` +
     getShellExportCommands(shadowboxSettings, name, metricsEnabled) +
     do_install_script.SCRIPT


### PR DESCRIPTION
Reverts https://github.com/OutlineFoundation/outline-apps/issues/2761, and implements the fix discussed in https://github.com/digitalocean/droplet-agent/issues/224#issuecomment-4649125623. Fixes https://github.com/OutlineFoundation/outline-apps/issues/2761.

The fix is to modify

```
#!/bin/sh set -eu\n
```

to 

```
#!/bin/sh
set -eu\n
```

I have no idea what is going on with DO that that works, but it does work.

Tested:
created a droplet with a manager built from this branch, saw that Web Console connected successfully.