### PR TITLE
chore: delete GEMINI.md files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+This project uses AGENTS.md instead of CLAUDE.md.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,1 +1,0 @@
-AGENTS.md

--- a/client/GEMINI.md
+++ b/client/GEMINI.md
@@ -1,1 +1,0 @@
-AGENTS.md

--- a/client/electron/GEMINI.md
+++ b/client/electron/GEMINI.md
@@ -1,1 +1,0 @@
-AGENTS.md

--- a/client/go/outline/configregistry/GEMINI.md
+++ b/client/go/outline/configregistry/GEMINI.md
@@ -1,1 +1,0 @@
-AGENTS.md

--- a/client/src/cordova/android/GEMINI.md
+++ b/client/src/cordova/android/GEMINI.md
@@ -1,1 +1,0 @@
-AGENTS.md

--- a/client/src/cordova/apple/GEMINI.md
+++ b/client/src/cordova/apple/GEMINI.md
@@ -1,1 +1,0 @@
-AGENTS.md

--- a/server_manager/GEMINI.md
+++ b/server_manager/GEMINI.md
@@ -1,1 +1,0 @@
-AGENTS.md


### PR DESCRIPTION
Delete GEMINI.md files, since Google tools already read AGENTS.md. This avoids duplicated context.
Also make CLAUDE.md know we use AGENTS.md. Also avoid symlink to prevent duplicated file loading.