### PR TITLE
feat(client/ios): scope Control Center reload to the Outline control

### DIFF
--- a/client/src/cordova/apple/xcode/Outline.xcodeproj/project.pbxproj
+++ b/client/src/cordova/apple/xcode/Outline.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		5260B05F2C4F0A4E00CDF289 /* VpnExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 5260B05C2C4F09FB00CDF289 /* VpnExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		52CE53E7295B6A310064D03D /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 52CE53E6295B6A310064D03D /* Sentry */; };
 		A30000012F40000000000001 /* OutlineControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = A30000072F40000000000007 /* OutlineControls.swift */; };
+		A30000132F40000000000013 /* OutlineControlKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = A30000122F40000000000012 /* OutlineControlKind.swift */; };
+		A30000142F40000000000014 /* OutlineControlKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = A30000122F40000000000012 /* OutlineControlKind.swift */; };
 		A30000022F40000000000002 /* OutlineControls.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = A30000052F40000000000005 /* OutlineControls.appex */; platformFilter = ios; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		5F7F90AE0E924FD7B065C415 /* CDVStatusBar.m in Sources */ = {isa = PBXBuildFile; fileRef = 0394302BA6114B2AB648D4FF /* CDVStatusBar.m */; };
 		65A9AC9C2BEC091700C5899F /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 65A9AC9B2BEC091700C5899F /* PrivacyInfo.xcprivacy */; };
@@ -160,6 +162,7 @@
 		8D1107310486CEB800E47090 /* Outline-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "Outline-Info.plist"; path = "Outline/Outline-Info.plist"; plistStructureDefinitionIdentifier = "com.apple.xcode.plist.structure-definition.iphone.info-plist"; sourceTree = SOURCE_ROOT; };
 		A30000052F40000000000005 /* OutlineControls.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = OutlineControls.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		A30000072F40000000000007 /* OutlineControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutlineControls.swift; sourceTree = "<group>"; };
+		A30000122F40000000000012 /* OutlineControlKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutlineControlKind.swift; sourceTree = "<group>"; };
 		A30000082F40000000000008 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A30000092F40000000000009 /* OutlineControls.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = OutlineControls.entitlements; sourceTree = "<group>"; };
 		91E45572BB494E9299D2DD41 /* CDVClipboard.m */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.objc; name = CDVClipboard.m; path = "cordova-plugin-clipboard/CDVClipboard.m"; sourceTree = "<group>"; };
@@ -427,6 +430,7 @@
 			isa = PBXGroup;
 			children = (
 				A30000072F40000000000007 /* OutlineControls.swift */,
+				A30000122F40000000000012 /* OutlineControlKind.swift */,
 				A30000082F40000000000008 /* Info.plist */,
 				A30000092F40000000000009 /* OutlineControls.entitlements */,
 			);
@@ -751,6 +755,7 @@
 				302D95F114D2391D003F00A1 /* MainViewController.m in Sources */,
 				5F7F90AE0E924FD7B065C415 /* CDVStatusBar.m in Sources */,
 				2A617D29B96942E58B082FAC /* OutlinePlugin.swift in Sources */,
+				A30000142F40000000000014 /* OutlineControlKind.swift in Sources */,
 				1273B4E700B84E31B2528701 /* CDVClipboard.m in Sources */,
 				A271D42D2A708240009981B2 /* AppDelegate+Outline.m in Sources */,
 			);
@@ -770,6 +775,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A30000012F40000000000001 /* OutlineControls.swift in Sources */,
+				A30000132F40000000000013 /* OutlineControlKind.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/client/src/cordova/apple/xcode/OutlineControls/OutlineControlKind.swift
+++ b/client/src/cordova/apple/xcode/OutlineControls/OutlineControlKind.swift
@@ -1,0 +1,25 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Identifiers for the Outline Control Center controls.
+///
+/// This file is compiled into both the OutlineControls widget extension and the
+/// main app (cordova-plugin-outline). Sharing the source guarantees the control
+/// registration in the extension and the app's
+/// `ControlCenter.reloadControls(ofKind:)` calls always use the same kind
+/// string, so a single edit here keeps them in sync.
+enum OutlineControlKind {
+  /// Kind identifier for the Outline VPN Control Center toggle.
+  static let vpnToggle = "org.outline.ios.client.OutlineVpnToggleControl"
+}

--- a/client/src/cordova/apple/xcode/OutlineControls/OutlineControls.swift
+++ b/client/src/cordova/apple/xcode/OutlineControls/OutlineControls.swift
@@ -212,7 +212,7 @@ struct OutlineVpnControlValue {
 
 @available(iOS 18.0, *)
 struct OutlineVpnToggleControl: ControlWidget {
-  static let kind = "org.outline.ios.client.OutlineVpnToggleControl"
+  static let kind = OutlineControlKind.vpnToggle
 
   var body: some ControlWidgetConfiguration {
     StaticControlConfiguration(kind: Self.kind, provider: Provider()) { value in
@@ -307,7 +307,7 @@ private struct OutlineControlsUnavailableProvider: TimelineProvider {
 }
 
 private struct OutlineControlsUnavailableWidget: Widget {
-  private let kind = "org.outline.ios.client.OutlineVpnToggleControl"
+  private let kind = OutlineControlKind.vpnToggle
 
   var body: some WidgetConfiguration {
     StaticConfiguration(kind: kind, provider: OutlineControlsUnavailableProvider()) { _ in

--- a/client/src/cordova/apple/xcode/OutlineControls/OutlineControls.swift
+++ b/client/src/cordova/apple/xcode/OutlineControls/OutlineControls.swift
@@ -24,6 +24,10 @@ private enum OutlineVpnControlBridge {
     static let transport = "transport"
   }
 
+  /// Maximum time to wait for the VPN to reach a stopped state before giving up,
+  /// so the caller (e.g. a Control Center intent) can never block indefinitely.
+  private static let kStopTunnelTimeoutNanoseconds: UInt64 = 10 * NSEC_PER_SEC
+
   static func currentState() async -> (isConnected: Bool, serverName: String?) {
     guard let manager = await getTunnelManager() else {
       return (false, nil)
@@ -78,32 +82,59 @@ private enum OutlineVpnControlBridge {
     await stopTunnel(manager.connection)
   }
 
+  /// Stops the tunnel and waits until the connection reaches a stopped state.
+  ///
+  /// `.NEVPNStatusDidChange` is delivered on the main thread while this runs on a
+  /// background cooperative thread, so the continuation is guarded by `ResumeOnce`
+  /// to guarantee a single, race-free resume (resuming a continuation twice traps).
+  /// A timeout ensures a stuck or immediately-reconnecting session can never block
+  /// the caller forever.
   private static func stopTunnel(_ connection: NEVPNConnection) async {
     guard !isStoppedSession(connection) else {
       return
     }
 
-    class TokenHolder {
+    // Runs its body at most once, safe to call from multiple threads.
+    final class ResumeOnce {
+      private let lock = NSLock()
+      private var hasRun = false
+
+      func run(_ body: () -> Void) {
+        lock.lock()
+        let shouldRun = !hasRun
+        hasRun = true
+        lock.unlock()
+        if shouldRun {
+          body()
+        }
+      }
+    }
+
+    final class TokenHolder {
       var token: NSObjectProtocol?
     }
+
+    let resumeOnce = ResumeOnce()
     let tokenHolder = TokenHolder()
 
     await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-      var didResume = false
+      func finish() {
+        resumeOnce.run {
+          if let token = tokenHolder.token {
+            NotificationCenter.default.removeObserver(
+              token,
+              name: .NEVPNStatusDidChange,
+              object: connection
+            )
+          }
+          continuation.resume()
+        }
+      }
 
-      func resumeIfStopped() {
-        guard isStoppedSession(connection), !didResume else {
-          return
+      func finishIfStopped() {
+        if isStoppedSession(connection) {
+          finish()
         }
-        didResume = true
-        if let token = tokenHolder.token {
-          NotificationCenter.default.removeObserver(
-            token,
-            name: .NEVPNStatusDidChange,
-            object: connection
-          )
-        }
-        continuation.resume()
       }
 
       tokenHolder.token = NotificationCenter.default.addObserver(
@@ -111,11 +142,18 @@ private enum OutlineVpnControlBridge {
         object: connection,
         queue: nil
       ) { _ in
-        resumeIfStopped()
+        finishIfStopped()
+      }
+
+      // Fail open: never block the caller forever if the session does not reach a
+      // stopped state (for example, if on-demand immediately reconnects).
+      Task {
+        try? await Task.sleep(nanoseconds: kStopTunnelTimeoutNanoseconds)
+        finish()
       }
 
       connection.stopVPNTunnel()
-      resumeIfStopped()
+      finishIfStopped()
     }
   }
 

--- a/client/src/cordova/plugin/apple/src/OutlinePlugin.swift
+++ b/client/src/cordova/plugin/apple/src/OutlinePlugin.swift
@@ -53,10 +53,14 @@ class OutlinePlugin: CDVPlugin {
   #endif
   private static let kAppGroup = "group.org.getoutline.client"
 
+  // Must match OutlineVpnToggleControl.kind in the OutlineControls extension.
+  // The control type lives in a separate target, so it cannot be referenced directly here.
+  private static let kOutlineVpnControlKind = "org.outline.ios.client.OutlineVpnToggleControl"
+
   private func reloadOutlineControls() {
     #if os(iOS) && !targetEnvironment(macCatalyst)
       if #available(iOS 18.0, *) {
-        ControlCenter.shared.reloadAllControls()
+        ControlCenter.shared.reloadControls(ofKind: OutlinePlugin.kOutlineVpnControlKind)
       }
     #endif
   }

--- a/client/src/cordova/plugin/apple/src/OutlinePlugin.swift
+++ b/client/src/cordova/plugin/apple/src/OutlinePlugin.swift
@@ -53,14 +53,10 @@ class OutlinePlugin: CDVPlugin {
   #endif
   private static let kAppGroup = "group.org.getoutline.client"
 
-  // Must match OutlineVpnToggleControl.kind in the OutlineControls extension.
-  // The control type lives in a separate target, so it cannot be referenced directly here.
-  private static let kOutlineVpnControlKind = "org.outline.ios.client.OutlineVpnToggleControl"
-
   private func reloadOutlineControls() {
     #if os(iOS) && !targetEnvironment(macCatalyst)
       if #available(iOS 18.0, *) {
-        ControlCenter.shared.reloadControls(ofKind: OutlinePlugin.kOutlineVpnControlKind)
+        ControlCenter.shared.reloadControls(ofKind: OutlineControlKind.vpnToggle)
       }
     #endif
   }


### PR DESCRIPTION
Related to https://github.com/OutlineFoundation/outline-apps/pull/2768. Making this a separate PR to test CI, but these commits should actually be merged into that branch.

- Narrow reloadAllControls() to reloadControls(ofKind:) so VPN status changes only reload the Outline VPN control instead of every control on the system.
- Hang fix: Added a 10-second timeout to stopTunnel so the Control Center intent's perform() can never block indefinitely if the VPN never reaches a stopped state (e.g. on-demand immediately reconnects).
- Data-race fix: Guarded the continuation with a lock-backed ResumeOnce so it resumes exactly once across the background-thread, main-thread observer, and timeout call sites, eliminating the double-resume() crash.

The windows CI issue is unrelated and fixed in https://github.com/OutlineFoundation/outline-apps/pull/2785

tested: built macos and ios successfully