### PR TITLE
feat(manager): build arm64 Manager artifacts for Linux and Windows

### DIFF
--- a/server_manager/electron/build.action.sh
+++ b/server_manager/electron/build.action.sh
@@ -73,3 +73,9 @@ cd "${STATIC_DIR}"
 # Icons.
 cd "${ROOT_DIR}"
 cp -r server_manager/electron/icons/ "${BUILD_DIR}/server_manager/electron/static/icons/"
+
+# NSIS custom installer include (Windows). electron-builder resolves
+# nsis.include relative to the app's buildResources dir ("build") under the
+# packaged project dir, so stage it there.
+mkdir -p "${STATIC_DIR}/build"
+cp server_manager/electron/windows/uninstall_legacy_ia32.nsh "${STATIC_DIR}/build/"

--- a/server_manager/electron/electron_builder.json
+++ b/server_manager/electron/electron_builder.json
@@ -25,6 +25,9 @@
       }
     ]
   },
+  "nsis": {
+    "include": "uninstall_legacy_ia32.nsh"
+  },
   "mac": {
     "hardenedRuntime": true,
     "entitlements": "server_manager/electron/release/macos.entitlements",

--- a/server_manager/electron/electron_builder.json
+++ b/server_manager/electron/electron_builder.json
@@ -1,13 +1,13 @@
 {
   "asarUnpack": ["server_manager/www/images"],
-  "artifactName": "Outline-Manager.${ext}",
+  "artifactName": "Outline-Manager-${arch}.${ext}",
   "linux": {
     "icon": "icons/png",
     "category": "Network",
     "target": [
       {
         "target": "AppImage",
-        "arch": ["x64"]
+        "arch": ["x64", "arm64"]
       }
     ]
   },
@@ -18,7 +18,7 @@
     "target": [
       {
         "target": "nsis",
-        "arch": "ia32"
+        "arch": ["ia32", "arm64"]
       }
     ]
   },

--- a/server_manager/electron/electron_builder.json
+++ b/server_manager/electron/electron_builder.json
@@ -1,6 +1,6 @@
 {
   "asarUnpack": ["server_manager/www/images"],
-  "artifactName": "Outline-Manager-${arch}.${ext}",
+  "artifactName": "Outline-Manager.${ext}",
   "linux": {
     "icon": "icons/png",
     "category": "Network",
@@ -10,6 +10,9 @@
         "arch": ["x64", "arm64"]
       }
     ]
+  },
+  "appImage": {
+    "artifactName": "Outline-Manager-${arch}.${ext}"
   },
   "win": {
     "icon": "icons/win/icon.ico",

--- a/server_manager/electron/package.action.sh
+++ b/server_manager/electron/package.action.sh
@@ -53,21 +53,34 @@ function package_electron() {
 function finish_yaml_files() {
   declare -r staging_percentage="${1?Staging percentage missing}"
 
+  # electron-builder names its auto-update manifests with a platform-specific
+  # suffix that is NOT the same as our PLATFORM value:
+  #   linux   -> latest-linux.yml
+  #   windows -> latest.yml         (no suffix)
+  #   macos   -> latest-mac.yml
+  local yaml_suffix
+  case "${PLATFORM}" in
+    linux) yaml_suffix='-linux';;
+    windows) yaml_suffix='';;
+    macos) yaml_suffix='-mac';;
+    *) echo "Unsupported platform ${PLATFORM}" >&2 && exit 1;;
+  esac
+
   local release_channel
   release_channel=$(node_modules/node-jq/bin/jq -r '.version' server_manager/package.json | cut -s -d'-' -f2)
   # If this isn't an alpha or beta build, `cut -s` will return an empty string
   if [[ -z "${release_channel}" ]]; then
     release_channel=latest
   fi
-  echo "stagingPercentage: ${staging_percentage}" >> "${PROJECT_DIR}/dist/${release_channel}${PLATFORM}.yml"
+  echo "stagingPercentage: ${staging_percentage}" >> "${PROJECT_DIR}/dist/${release_channel}${yaml_suffix}.yml"
 
   # If we cut a staged mainline release, beta testers will take the update as well.
   if [[ "${release_channel}" == "latest" ]]; then
-    echo "stagingPercentage: ${staging_percentage}" >> "${PROJECT_DIR}/dist/beta${PLATFORM}.yml"
+    echo "stagingPercentage: ${staging_percentage}" >> "${PROJECT_DIR}/dist/beta${yaml_suffix}.yml"
   fi
 
   # We don't support alpha releases
-  rm -f "${PROJECT_DIR}/dist/alpha${PLATFORM}.yml"
+  rm -f "${PROJECT_DIR}/dist/alpha${yaml_suffix}.yml"
 }
 
 function main() {

--- a/server_manager/electron/package.action.sh
+++ b/server_manager/electron/package.action.sh
@@ -32,7 +32,7 @@ function package_electron() {
     linux)
       electron_builder_cmd+=(--linux);;
     windows)
-      electron_builder_cmd+=(--win --ia32);;
+      electron_builder_cmd+=(--win --ia32 --arm64);;
     macos)
       electron_builder_cmd+=(--mac);;
     *)

--- a/server_manager/electron/windows/uninstall_legacy_ia32.nsh
+++ b/server_manager/electron/windows/uninstall_legacy_ia32.nsh
@@ -1,0 +1,49 @@
+; Copyright 2024 The Outline Authors
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;      http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+!include LogicLib.nsh
+!include x64.nsh
+
+; Defensive migration cleanup for electron-builder#8672.
+;
+; The Manager historically shipped only a 32-bit (ia32) Windows build. On an
+; ARM64 Windows machine a user may have that ia32 build installed via x86
+; emulation. When they move to the new combined installer, the native arm64
+; slice runs in the 64-bit registry view and cannot see the ia32 install's
+; uninstall entry, which lives in the 32-bit (WOW6432Node) view. electron-builder's
+; built-in "uninstall previous version" step only checks the installer's own
+; view, so the stale 32-bit copy would be left behind alongside the new one.
+;
+; To avoid that, when the running installer is 64-bit (arm64/x64) we explicitly
+; look in the 32-bit view for a prior per-user install and, if one exists, run
+; its uninstaller silently before continuing. The common cases are unaffected:
+;  - 32-bit (ia32) installs share the 32-bit view, so ${RunningX64} gates this
+;    off and electron-builder's native same-view uninstall handles them.
+;  - Fresh arm64 installs find no stale entry and this is a no-op.
+;
+; NOTE: The Manager installer is per-user (perMachine=false, oneClick), so the
+; legacy entry lives under HKCU. This mitigation is best-effort and still needs
+; to be validated on an ARM64 Windows VM (ia32 -> combined upgrade path).
+!macro customInit
+  ${If} ${RunningX64}
+    SetRegView 32
+    ReadRegStr $R1 HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${UNINSTALL_APP_KEY}" "QuietUninstallString"
+    SetRegView lastused
+    ${If} $R1 != ""
+      DetailPrint "Removing previous 32-bit Outline Manager installation (electron-builder#8672)..."
+      ; QuietUninstallString already includes the silent (/S) flag.
+      ExecWait '$R1'
+    ${EndIf}
+  ${EndIf}
+!macroend


### PR DESCRIPTION
Add arm64 targets for the Outline Manager desktop app. After this change (and some releases we still need to do) we will support arm64 across all our released artifacts (manager/client/server).

Platforms:
- Linux AppImage: x64 + arm64
- Windows nsis: ia32 + arm64. I am keeping the existing windows version as ia32 due to https://github.com/electron-userland/electron-builder/issues/8672

Switch artifactName to include ${arch} so the per-arch artifacts don't overwrite each other (mirrors client #2779). Update the Windows packaging branch to pass --ia32 --arm64.

The Manager is a pure-JS Electron app with no native modules, so Electron's prebuilt arm64 binaries are sufficient and no cross-compilation is needed.

Followups:
- will require some changes to our release process documentation
- will require some website/devdoc updates with the new links.