### PR TITLE
fix(client/android): fix/added intent verification

### DIFF
--- a/client/src/cordova/android/OutlineAndroidLib/outline/src/main/java/org/outline/vpn/VpnServiceStarter.java
+++ b/client/src/cordova/android/OutlineAndroidLib/outline/src/main/java/org/outline/vpn/VpnServiceStarter.java
@@ -26,6 +26,9 @@ public class VpnServiceStarter extends BroadcastReceiver {
 
   @Override
   public void onReceive(Context context, Intent intent) {
+    if (intent == null || !Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction())) {
+        return; // reject anything that isn't the exact expected system action
+    }
     final VpnTunnelStore tunnelStore = new VpnTunnelStore(context);
     boolean wasConnectedAtShutdown =
         VpnTunnelService.TunnelStatus.CONNECTED.equals(tunnelStore.getTunnelStatus());

--- a/client/src/cordova/android/OutlineAndroidLib/outline/src/main/java/org/outline/vpn/VpnServiceStarter.java
+++ b/client/src/cordova/android/OutlineAndroidLib/outline/src/main/java/org/outline/vpn/VpnServiceStarter.java
@@ -26,9 +26,17 @@ public class VpnServiceStarter extends BroadcastReceiver {
 
   @Override
   public void onReceive(Context context, Intent intent) {
-    if (intent == null || !Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction())) {
-        return; // reject anything that isn't the exact expected system action
+    if (intent == null) {
+      return;
     }
+    
+    final String action = intent.getAction();
+    if (action == null
+        || (!Intent.ACTION_BOOT_COMPLETED.equals(action)
+            && !Intent.ACTION_MY_PACKAGE_REPLACED.equals(action))) {
+      return;
+    }
+    
     final VpnTunnelStore tunnelStore = new VpnTunnelStore(context);
     boolean wasConnectedAtShutdown =
         VpnTunnelService.TunnelStatus.CONNECTED.equals(tunnelStore.getTunnelStatus());


### PR DESCRIPTION
Added verification of intent by broadcast receiver
The receiver now verifies intents it receives before processing

This is to fix this failing check: https://github.com/OutlineFoundation/outline-apps/pull/2783/checks?check_run_id=84031422688