### PR TITLE
feat(manager): playwright QA automation suite for the manager UI

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,8 @@
       "./client/tsconfig.json",
       "./client/capacitor/tsconfig.json",
       "./infrastructure/tsconfig.json",
-      "./server_manager/tsconfig.json"
+      "./server_manager/tsconfig.json",
+      "./server_manager/e2e/tsconfig.json"
     ]
   },
   "plugins": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -152,6 +152,7 @@
         "server_manager/www/karma.conf.js",
         "server_manager/electron_main.webpack.mjs",
         "server_manager/electron_preload.webpack.mjs",
+        "server_manager/e2e/test.action.mjs",
         ".prettierrc.js",
         "client/web/karma.conf.js"
       ],

--- a/.github/workflows/build_and_test_debug_manager.yml
+++ b/.github/workflows/build_and_test_debug_manager.yml
@@ -50,6 +50,38 @@ jobs:
       - name: Manager Web Test
         run: npm run action server_manager/test
 
+  manager_ui_e2e_test:
+    name: Manager UI E2E Test
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: ./server_manager/package.json
+
+      - name: Install NPM Dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Manager UI E2E Suite
+        run: npm run action server_manager/e2e/test
+
+      - name: Upload Playwright Report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: server_manager/e2e/playwright-report
+          retention-days: 14
+
   linux_debug_build:
     name: Linux Debug Build
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ node_modules
 
 # Capacitor web build output
 client/capacitor/www/
+
+# Playwright E2E artifacts
+server_manager/e2e/test-results/
+server_manager/e2e/playwright-report/

--- a/docs/manager-qa-automation-plan.md
+++ b/docs/manager-qa-automation-plan.md
@@ -1,0 +1,198 @@
+# Manager QA Automation Plan
+
+This document describes the plan for converting the manual OutlineVPN Server
+Manager QA checklist ([go/outlinevpn-manager-qa](http://go/outlinevpn-manager-qa))
+into an automated test suite. Each manual checklist item has a stable
+identifier (e.g. `ServerCreate.Manual`, `App.Certificate.Windows.Installer`);
+automated tests are tagged with these identifiers so that coverage can be
+traced and a release sign-off sheet can be generated automatically.
+
+It is the Manager counterpart of the client plan in
+[qa-automation-plan.md](qa-automation-plan.md) and follows the same layering
+and traceability conventions.
+
+## Architecture insight
+
+The Manager is one web UI ([server_manager/www](../server_manager/www),
+Polymer/Lit web components) wrapped by a thin Electron shell
+([server_manager/electron](../server_manager/electron)). Unlike the client,
+there is no native tunnel: *everything* the app does is plain HTTPS from the
+renderer —
+
+- the DigitalOcean REST API (`api.digitalocean.com`),
+- the GCP APIs (OAuth, Compute, Cloud Billing),
+- and the Shadowbox management API of each server.
+
+The Electron layer contributes only OAuth helpers, certificate-pinned fetch
+(`fetchWithPin`, used when a manual server config carries a `certSha256`),
+window management, and auto-update. A browser build already exists
+(`server_manager/browser.webpack.js` / `www/browser_main.ts`) that stubs all
+of these.
+
+Consequently, almost the entire checklist can be automated in a plain
+browser with network interception:
+
+- Manual servers added *without* a certificate fingerprint use plain
+  `window.fetch`, so Playwright's `page.route()` can impersonate a complete
+  Shadowbox management API while the app runs 100% real code (repository,
+  storage, UI). No fake objects need to be injected at all.
+- `ManualServerRepository` and `CloudAccounts` persist to `localStorage`, so
+  "restart the manager" checklist steps become `page.reload()`.
+- The DigitalOcean flow is equally interceptable: the browser build's OAuth
+  stub asks for a token via `window.prompt` (answerable from Playwright), and
+  every subsequent call is REST against `api.digitalocean.com`.
+- Only installers, signatures, real cloud-provider behavior, and the Electron
+  shell itself need heavier harnesses.
+
+## The five layers
+
+### Layer 1 — Manager UI suite (Playwright, browser build)
+
+Runs on every PR on `ubuntu-latest`. Builds the browser bundle
+(`server_manager/browser.webpack.js`), serves it statically, drives it with
+[Playwright](https://playwright.dev) (same tooling as the client suite; it
+pierces Shadow DOM natively — essential for the Polymer app shell — and also
+covers Electron in Layer 3).
+
+Groundwork:
+
+1. **Route-intercepted Shadowbox API** — a scriptable in-test fake of the
+   management API (`/server`, `/access-keys`, `/metrics/transfer`, …) mounted
+   on an `https://` origin via `page.route()` (the page CSP allows any
+   `https:` connect target, and intercepted requests never leave the
+   browser).
+2. **Stable selectors** — `data-testid` attributes on the intro cards, manual
+   server entry, server list, access-key table and its controls, and the
+   feedback/about/language surfaces.
+
+Covers: `App.Start`, `ServerCreate.Manual`, `ServerConnect.Manual`,
+`ServerDestroy.Manual`, `Key.Add`, `Key.Delete`, `Key.Share` (UI half:
+the access key is displayed and copyable), `Key.UsageData`, `Ui.I18n`,
+`Ui.About` (partial: version string, no `-dev` check on release artifacts),
+`Report.UserFeedback` (partial: success path at UI level — the browser build
+initializes Sentry without a DSN, so no outgoing request exists to intercept
+until the `@sentry/browser` split in
+[#1311](https://github.com/Jigsaw-Code/outline-apps/issues/1311) lands).
+
+Phase 2 of this layer adds the DigitalOcean flows against an intercepted DO
+API (`ServerCreate.DigitalOcean`, `ServerConnect.DigitalOcean`,
+`ServerDestroy.DigitalOcean` — UI halves), which requires mocking the
+droplet-creation/polling surface of the DO REST API. GCP similarly, with a
+larger mocked surface (OAuth token exchange, Compute, Billing).
+
+### Layer 2 — Real-Shadowbox integration (hermetic server, nightly)
+
+The manual-server tests from Layer 1 re-run against a *real* Shadowbox: a
+`docker run outline/shadowbox` container started on the runner, with the
+route-interception layer disabled. This proves the management-API contract
+(the Layer 1 fake and the real server can drift; this layer catches it).
+
+It also completes `Key.Share`: the acceptance criterion is that the Outline
+*Client* can connect with the shared key. The generated access key is handed
+to the client's Go transport library (`client/go`), which dials through the
+container — the same hermetic pattern as client Layer 2, reusing its
+harness.
+
+Covers: `ServerCreate.Manual` / `Key.*` (full-stack halves), `Key.Share`
+(connect check).
+
+### Layer 3 — Desktop E2E (Playwright Electron, Windows + Linux + macOS)
+
+Playwright's `_electron.launch()` drives the real main process and renderer:
+app starts, window opens, servers persist across a real app restart, the app
+quits cleanly (no orphan process), and the OAuth windows open. The
+Shadowbox fake from Layer 1 cannot intercept here, so these tests either run
+UI-only flows or point at the Layer 2 container.
+
+Covers: `App.Start`, `App.Terminate`, `ServerConnect.Manual` (real restart),
+`Ui.MainIcon` (partial: window/dock icon present).
+
+### Layer 4 — Cloud-provider canary (real DO/GCP, release gate)
+
+The only honest test of `ServerCreate.DigitalOcean` / `ServerCreate.GCP` is
+against the real providers: create a droplet/VM with a dedicated test
+account, wait for the Shadowbox install to complete, add a key, connect,
+destroy. Expensive and slow, so it runs on manual dispatch as part of the
+release gate (optionally weekly), with credentials in repository secrets and
+an always-run destroy step to bound cost.
+
+Covers: `ServerCreate.DigitalOcean`, `ServerCreate.GCP`,
+`ServerConnect.DigitalOcean`, `ServerConnect.GCP`,
+`ServerDestroy.DigitalOcean`, `ServerDestroy.GCP` (full-stack).
+
+### Layer 5 — Installer & lifecycle checks (scripted, release gate)
+
+PowerShell/bash scripts in a release-gate workflow, run against signed
+artifacts (shared with the client's Layer 5 workflow):
+
+- **Signature (P0)**: `Get-AuthenticodeSignature` on `Outline-Manager.exe` —
+  exactly one valid signature, issued to "Jigsaw Operations LLC", valid
+  dates. macOS: `spctl -a -vvvv -t execute` — accepted, Notarized Developer
+  ID.
+- **Clean install**: fresh hosted Windows runner as the clean VM; silent
+  install, assert exit code, installed files, Start Menu entry.
+- **Reinstall/Upgrade/Uninstall**: previous release → current release,
+  assert persisted servers (localStorage in the user profile survives);
+  uninstall and assert clean removal. Linux: same pattern with the
+  `.AppImage`.
+
+Covers: `App.Certificate.Windows.Installer`, `App.Notarization.MacOS`,
+`App.Install.Clean`, `App.Install.Reinstall`, `App.Install.Upgrade`,
+`App.Uninstall`.
+
+## CI shape
+
+| Trigger | Contents |
+| :--- | :--- |
+| Per-PR | Layer 1 Playwright UI suite, existing unit tests (`server_manager/test`). Fast and hermetic. |
+| Nightly | Layer 2 Shadowbox-container suite, Layer 3 Electron E2E. |
+| Release gate (manual dispatch) | Layer 4 cloud canary, Layer 5 installer checks on signed artifacts, full nightly suite pinned to the release build, sign-off sheet generation. |
+
+## Traceability & sign-off generation
+
+Every automated test is tagged with its checklist ID (`ServerCreate.Manual`,
+`App.Certificate.Windows.Installer`, …). The release workflow aggregates
+results and generates the sign-off sheet: each ID marked pass / fail /
+not-automated with a link to the CI run. Items that remain manual are listed
+explicitly. Shared with the client plan's Phase 5 tooling.
+
+## What stays manual
+
+- Cloud-provider *console-side* verification (droplet visible in the DO
+  dashboard, billing states, GCP project quirks) beyond what the APIs report.
+- `Ui.MainIcon` visual judgment (icon *looks* correct in taskbar/dock).
+- OAuth against the real DO/GCP consent screens (provider UX changes at
+  will; the canary uses pre-issued tokens).
+- Visual/UX judgment calls.
+
+## Phasing & status
+
+- [ ] **Phase 0 — groundwork**
+  - [x] Route-intercepted Shadowbox management API fake
+        (`server_manager/e2e/tests/fake_shadowbox.ts`)
+  - [x] `data-testid` attributes on key components (intro, manual entry,
+        server list, access-key table/controls, help bubbles)
+  - [ ] Shadowbox container harness for Layer 2
+- [ ] **Phase 1 — per-PR suite**
+  - [x] Playwright Manager UI suite, tagged with checklist IDs
+        (`server_manager/e2e`; covers App.Start, ServerCreate.Manual,
+        ServerConnect.Manual, ServerDestroy.Manual, Key.Add, Key.Delete,
+        Key.Share (UI), Key.UsageData, Ui.I18n, Ui.About,
+        Report.UserFeedback (UI))
+  - [x] Wire the suite into per-PR CI (`manager_e2e_test` job in
+        build_and_test_debug_manager.yml)
+  - [ ] DigitalOcean flows against an intercepted DO API
+  - [ ] GCP flows against an intercepted GCP API
+- [ ] **Phase 2 — hermetic real server**
+  - [ ] Nightly job running the manual-server suite against a Shadowbox
+        container
+  - [ ] Key.Share connect check via the client Go library
+- [ ] **Phase 3 — desktop E2E**
+  - [ ] Playwright Electron on Linux and Windows
+  - [ ] macOS run (hosted runner)
+- [ ] **Phase 4 — release gate**
+  - [ ] Cloud canary workflow (real DO/GCP, secrets, auto-destroy)
+  - [ ] Installer/signature scripts (shared with client Layer 5)
+- [ ] **Phase 5 — sign-off automation**
+  - [ ] Results aggregation + sign-off sheet generation (shared tooling with
+        the client plan)

--- a/package-lock.json
+++ b/package-lock.json
@@ -186,14 +186,15 @@
       "devDependencies": {
         "@capacitor/cli": "^6.0.0",
         "@outline/infrastructure": "file:../../infrastructure",
-        "copy-webpack-plugin": "^5.1.1",
+        "copy-webpack-plugin": "^12.0.2",
         "css-loader": "^7.1.4",
         "html-webpack-plugin": "^5.6.6",
         "style-loader": "^4.0.0",
         "ts-loader": "^9.5.7",
         "webpack": "^5.16.0",
         "webpack-cli": "^4.4.0",
-        "webpack-dev-server": "^4.5.0"
+        "webpack-dev-server": "^4.5.0",
+        "webpack-merge": "^5.8.0"
       }
     },
     "client/capacitor/node_modules/chalk": {
@@ -1335,16 +1336,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "client/node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
       }
     },
     "client/node_modules/slash": {
@@ -8606,6 +8597,22 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@polymer/app-layout": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@polymer/app-layout/-/app-layout-3.1.0.tgz",
@@ -14349,6 +14356,19 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/batch": {
       "version": "0.6.1",
       "dev": true,
@@ -15143,41 +15163,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/cacache": {
-      "version": "12.0.4",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "bluebird": "^3.5.5",
-        "chownr": "^1.1.1",
-        "figgy-pudding": "^3.5.1",
-        "glob": "^7.1.4",
-        "graceful-fs": "^4.1.15",
-        "infer-owner": "^1.0.3",
-        "lru-cache": "^5.1.1",
-        "mississippi": "^3.0.0",
-        "mkdirp": "^0.5.1",
-        "move-concurrently": "^1.0.1",
-        "promise-inflight": "^1.0.1",
-        "rimraf": "^2.6.3",
-        "ssri": "^6.0.1",
-        "unique-filename": "^1.1.1",
-        "y18n": "^4.0.0"
-      }
-    },
-    "node_modules/cacache/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/cacache/node_modules/yallist": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/cache-base": {
       "version": "1.0.1",
@@ -17402,6 +17387,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/corser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+      "integrity": "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/crc": {
@@ -24946,6 +24941,19 @@
         "wbuf": "^1.1.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/html-entities": {
       "version": "2.3.3",
       "dev": true,
@@ -25188,6 +25196,64 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/http-server": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
+      "integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "^2.0.1",
+        "chalk": "^4.1.2",
+        "corser": "^2.0.1",
+        "he": "^1.2.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy": "^1.18.1",
+        "mime": "^1.6.0",
+        "minimist": "^1.2.6",
+        "opener": "^1.5.1",
+        "portfinder": "^1.0.28",
+        "secure-compare": "3.0.1",
+        "union": "~0.5.0",
+        "url-join": "^4.0.1"
+      },
+      "bin": {
+        "http-server": "bin/http-server"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/http-server/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/http-server/node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/http-signature": {
@@ -31408,6 +31474,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
+      }
+    },
     "node_modules/opn": {
       "version": "5.5.0",
       "dev": true,
@@ -32257,6 +32333,53 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/plist": {
       "version": "3.1.0",
@@ -34940,6 +35063,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/secure-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
+      "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/seek-bzip": {
       "version": "1.0.6",
@@ -38253,6 +38383,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/union": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
+      "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
+      "dev": true,
+      "dependencies": {
+        "qs": "^6.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -38482,6 +38624,13 @@
         "punycode": "1.3.2",
         "querystring": "0.2.0"
       }
+    },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/url-parse-lax": {
       "version": "3.0.0",
@@ -39412,6 +39561,20 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/whatwg-fetch": {
       "version": "3.6.2",
       "dev": true,
@@ -40207,6 +40370,7 @@
         "web-animations-js": "^2.3.2"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@types/node": "^16.11.29",
         "@types/node-forge": "^1.0.2",
         "@types/polymer": "^1.2.9",
@@ -40223,6 +40387,7 @@
         "gulp-posthtml": "^3.0.4",
         "gulp-replace": "^1.0.0",
         "html-webpack-plugin": "^5.5.3",
+        "http-server": "^14.1.1",
         "jasmine": "^5.1.0",
         "karma": "^6.3.16",
         "karma-chrome-launcher": "^3.1.0",
@@ -47377,15 +47542,6 @@
           "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
           "dev": true
         },
-        "serialize-javascript": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-          "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-          "dev": true,
-          "requires": {
-            "randombytes": "^2.1.0"
-          }
-        },
         "slash": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
@@ -47471,7 +47627,7 @@
         "@sentry/browser": "^7.31.1",
         "@webcomponents/webcomponentsjs": "^2.4.4",
         "capacitor-plugin-outline": "file:plugins/capacitor-plugin-outline",
-        "copy-webpack-plugin": "^5.1.1",
+        "copy-webpack-plugin": "^12.0.2",
         "core-js": "^3.49.0",
         "css-loader": "^7.1.4",
         "html-webpack-plugin": "^5.6.6",
@@ -47481,7 +47637,8 @@
         "web-animations-js": "^2.3.2",
         "webpack": "^5.16.0",
         "webpack-cli": "^4.4.0",
-        "webpack-dev-server": "^4.5.0"
+        "webpack-dev-server": "^4.5.0",
+        "webpack-merge": "^5.8.0"
       },
       "dependencies": {
         "chalk": {
@@ -47495,7 +47652,8 @@
           }
         },
         "copy-webpack-plugin": {
-          "version": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-12.0.2.tgz",
+          "version": "12.0.2",
+          "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-12.0.2.tgz",
           "integrity": "sha512-SNwdBeHyII+rWvee/bTnAYyO8vfVdcSTud4EIb6jcZ8inLeWucJE0DnxXQBjlQ5zlteuuvooGQy3LIyGxhvlOA==",
           "dev": true,
           "requires": {
@@ -47725,6 +47883,7 @@
         "@material/mwc-textarea": "^0.27.0",
         "@material/mwc-textfield": "^0.27.0",
         "@outline/infrastructure": "file:../infrastructure",
+        "@playwright/test": "^1.61.1",
         "@polymer/app-layout": "^3.1.0",
         "@polymer/app-localize-behavior": "^3.0.1",
         "@polymer/font-roboto": "^3.0.2",
@@ -47773,6 +47932,7 @@
         "gulp-posthtml": "^3.0.4",
         "gulp-replace": "^1.0.0",
         "html-webpack-plugin": "^5.5.3",
+        "http-server": "^14.1.1",
         "intl-messageformat": "^7.8.4",
         "jasmine": "^5.1.0",
         "jsonic": "^0.3.1",
@@ -49193,6 +49353,15 @@
       "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
       "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
       "dev": true
+    },
+    "@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "requires": {
+        "playwright": "1.61.1"
+      }
     },
     "@polymer/app-layout": {
       "version": "3.1.0",
@@ -53515,6 +53684,15 @@
       "integrity": "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==",
       "dev": true
     },
+    "basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
     "batch": {
       "version": "0.6.1",
       "dev": true
@@ -54113,12 +54291,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
-    },
-    "bytestreamjs": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
-      "integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
-      "dev": true
     },
     "cache-base": {
       "version": "1.0.1",
@@ -55675,6 +55847,12 @@
         "object-assign": "^4",
         "vary": "^1"
       }
+    },
+    "corser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+      "integrity": "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==",
+      "dev": true
     },
     "crc": {
       "version": "3.8.0",
@@ -61260,6 +61438,15 @@
         "wbuf": "^1.1.0"
       }
     },
+    "html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "requires": {
+        "whatwg-encoding": "^2.0.0"
+      }
+    },
     "html-entities": {
       "version": "2.3.3",
       "dev": true
@@ -61411,6 +61598,45 @@
       "dependencies": {
         "is-plain-obj": {
           "version": "3.0.0",
+          "dev": true
+        }
+      }
+    },
+    "http-server": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
+      "integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
+      "dev": true,
+      "requires": {
+        "basic-auth": "^2.0.1",
+        "chalk": "^4.1.2",
+        "corser": "^2.0.1",
+        "he": "^1.2.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy": "^1.18.1",
+        "mime": "^1.6.0",
+        "minimist": "^1.2.6",
+        "opener": "^1.5.1",
+        "portfinder": "^1.0.28",
+        "secure-compare": "3.0.1",
+        "union": "~0.5.0",
+        "url-join": "^4.0.1"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "mime": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
           "dev": true
         }
       }
@@ -65938,6 +66164,12 @@
         "is-wsl": "^2.2.0"
       }
     },
+    "opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true
+    },
     "opn": {
       "version": "5.5.0",
       "dev": true,
@@ -66516,6 +66748,31 @@
           "dev": true
         }
       }
+    },
+    "playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "requires": {
+        "fsevents": "2.3.2",
+        "playwright-core": "1.61.1"
+      },
+      "dependencies": {
+        "fsevents": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true
     },
     "plist": {
       "version": "3.1.0",
@@ -68477,6 +68734,12 @@
         "ajv-keywords": "^3.5.2"
       }
     },
+    "secure-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
+      "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
+      "dev": true
+    },
     "seek-bzip": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
@@ -70067,9 +70330,10 @@
           "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
           "dev": true,
           "requires": {
-            "@types/json-schema": "^7.0.8",
-            "ajv": "^6.12.5",
-            "ajv-keywords": "^3.5.2"
+            "@types/json-schema": "^7.0.9",
+            "ajv": "^8.9.0",
+            "ajv-formats": "^2.1.1",
+            "ajv-keywords": "^5.1.0"
           }
         },
         "supports-color": {
@@ -70908,6 +71172,15 @@
       "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
       "dev": true
     },
+    "union": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
+      "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
+      "dev": true,
+      "requires": {
+        "qs": "^6.4.0"
+      }
+    },
     "union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -71081,6 +71354,12 @@
           "dev": true
         }
       }
+    },
+    "url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "dev": true
     },
     "url-parse-lax": {
       "version": "3.0.0",
@@ -71757,6 +72036,15 @@
     "websocket-extensions": {
       "version": "0.1.4",
       "dev": true
+    },
+    "whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.6.3"
+      }
     },
     "whatwg-fetch": {
       "version": "3.6.2",

--- a/server_manager/e2e/README.md
+++ b/server_manager/e2e/README.md
@@ -1,0 +1,48 @@
+# Manager UI E2E Suite
+
+This is Layer 1 of the automated QA suite described in
+[docs/manager-qa-automation-plan.md](../../docs/manager-qa-automation-plan.md):
+Playwright tests that drive the real Manager web UI (the browser build)
+against a route-intercepted fake of the Shadowbox management API.
+
+Each test title starts with the QA checklist ID it automates (e.g.
+`ServerCreate.Manual`), so results can be traced back to — and eventually
+generate — the release sign-off sheet.
+
+## Running
+
+```sh
+npm run action server_manager/e2e/test
+```
+
+This builds the browser bundle and runs the suite headlessly. Extra
+arguments are forwarded to `playwright test`, e.g.:
+
+```sh
+npm run action server_manager/e2e/test -- --headed
+npm run action server_manager/e2e/test -- --grep "Key.Add"
+```
+
+If the bundle in `output/build/server_manager/www/static` is already up to
+date, you can run Playwright directly:
+
+```sh
+npx playwright test --config server_manager/e2e/playwright.config.ts
+```
+
+First-time setup installs the browser binary:
+
+```sh
+npx playwright install chromium
+```
+
+## Notes
+
+- Manual servers added without a certificate fingerprint use plain
+  `window.fetch`, so `FakeShadowbox` (tests/fake_shadowbox.ts) can
+  impersonate a complete management API with `page.route()` while the app
+  runs real code end to end — repository, `localStorage` persistence and UI.
+- Cloud-provider flows (DigitalOcean, GCP) are not covered here yet; see the
+  phasing section of the plan.
+- Prefer `data-testid` selectors (or existing stable `id`s); add new ones to
+  components rather than relying on classes or localized text.

--- a/server_manager/e2e/playwright.config.ts
+++ b/server_manager/e2e/playwright.config.ts
@@ -1,0 +1,58 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as path from 'path';
+
+import {defineConfig, devices} from '@playwright/test';
+
+const WWW_DIR = path.join(
+  __dirname,
+  '..',
+  '..',
+  'output',
+  'build',
+  'server_manager',
+  'www',
+  'static'
+);
+
+/**
+ * Manager UI E2E suite (QA automation Layer 1, see
+ * docs/manager-qa-automation-plan.md).
+ *
+ * Drives the browser build of the Manager: the real web UI running against
+ * a route-intercepted fake of the Shadowbox management API. Build the bundle
+ * first (`npx webpack --config=server_manager/browser.webpack.js`), or run
+ * the whole thing via `npm run action server_manager/e2e/test`.
+ */
+export default defineConfig({
+  testDir: './tests',
+  outputDir: './test-results',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI
+    ? [['list'], ['html', {open: 'never', outputFolder: './playwright-report'}]]
+    : 'list',
+  use: {
+    baseURL: 'http://localhost:18624',
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: `npx http-server "${WWW_DIR}" --port 18624 --silent -c-1`,
+    url: 'http://localhost:18624',
+    reuseExistingServer: !process.env.CI,
+  },
+  projects: [{name: 'chromium', use: {...devices['Desktop Chrome']}}],
+});

--- a/server_manager/e2e/test.action.mjs
+++ b/server_manager/e2e/test.action.mjs
@@ -1,0 +1,52 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import path from 'path';
+import url from 'url';
+
+import {getRootDir} from '@outline/infrastructure/build/get_root_dir.mjs';
+import {runAction} from '@outline/infrastructure/build/run_action.mjs';
+import {spawnStream} from '@outline/infrastructure/build/spawn_stream.mjs';
+
+/**
+ * @description Runs the Manager UI E2E suite (Playwright) against the
+ * browser build. Extra parameters are forwarded to `playwright test`.
+ *
+ * @param {string[]} parameters
+ */
+export async function main(...parameters) {
+  await runAction('server_manager/www/build_install_script');
+
+  // Build the browser bundle (the same one `server_manager/www/start`
+  // serves) to output/build/server_manager/www/static.
+  await spawnStream(
+    'npx',
+    'webpack',
+    '--config',
+    path.join(getRootDir(), 'server_manager', 'browser.webpack.js')
+  );
+
+  await spawnStream(
+    'npx',
+    'playwright',
+    'test',
+    '--config',
+    path.join(getRootDir(), 'server_manager', 'e2e', 'playwright.config.ts'),
+    ...parameters
+  );
+}
+
+if (import.meta.url === url.pathToFileURL(process.argv[1]).href) {
+  await main(...process.argv.slice(2));
+}

--- a/server_manager/e2e/tests/fake_shadowbox.ts
+++ b/server_manager/e2e/tests/fake_shadowbox.ts
@@ -1,0 +1,163 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type {Page, Route} from '@playwright/test';
+
+/**
+ * A fake Shadowbox management API, mounted into the page with
+ * `page.route()`.
+ *
+ * Manual servers added without a certificate fingerprint use plain
+ * `window.fetch` (see server_manager/www/fetcher.ts), so intercepting
+ * requests to the API URL lets the whole app — repository, storage and UI —
+ * run real code against a scriptable server. The URL must be `https:` to
+ * satisfy the page's CSP; the interception happens before any network
+ * access, so the host never needs to resolve.
+ *
+ * The endpoint surface mirrors what ShadowboxServer
+ * (server_manager/www/shadowbox_server.ts) calls.
+ */
+
+export interface FakeAccessKey {
+  id: string;
+  name: string;
+  accessUrl: string;
+}
+
+interface FakeShadowboxOptions {
+  apiUrl?: string;
+  name?: string;
+  version?: string;
+  /** Data usage reported by /metrics/transfer, keyed by access key id. */
+  bytesTransferredByKeyId?: {[keyId: string]: number};
+}
+
+export class FakeShadowbox {
+  readonly apiUrl: string;
+  private name: string;
+  private readonly version: string;
+  private metricsEnabled = false;
+  private readonly keys: FakeAccessKey[] = [];
+  private nextKeyId = 0;
+  private readonly bytesTransferredByKeyId: {[keyId: string]: number};
+
+  constructor(options: FakeShadowboxOptions = {}) {
+    // `.invalid` (RFC 2606) can never resolve, so a routing mistake fails
+    // fast instead of hitting a real host.
+    this.apiUrl = options.apiUrl ?? 'https://fake-shadowbox.invalid/TestApiKey';
+    this.name = options.name ?? 'Fake Shadowbox';
+    this.version = options.version ?? '1.6.0';
+    this.bytesTransferredByKeyId = options.bytesTransferredByKeyId ?? {};
+    // A freshly installed Shadowbox always has one key.
+    this.createKey();
+  }
+
+  /** The value to paste into the manual server entry screen. */
+  get config(): string {
+    return JSON.stringify({apiUrl: this.apiUrl});
+  }
+
+  listKeys(): readonly FakeAccessKey[] {
+    return this.keys;
+  }
+
+  private createKey(): FakeAccessKey {
+    const id = String(this.nextKeyId++);
+    const key = {
+      id,
+      name: '',
+      accessUrl: `ss://fake-secret-${id}@203.0.113.10:9999/?outline=1`,
+    };
+    this.keys.push(key);
+    return key;
+  }
+
+  /** Starts intercepting this fake's API URL on `page`. */
+  async install(page: Page): Promise<void> {
+    await page.route(`${this.apiUrl}/**`, route => this.handle(route));
+  }
+
+  private handle(route: Route): Promise<void> {
+    const request = route.request();
+    const url = new URL(request.url());
+    // Path relative to the base API URL, e.g. 'access-keys/3/name'.
+    const path = url.pathname
+      .substring(new URL(this.apiUrl).pathname.length)
+      .replace(/^\//, '');
+    const method = request.method();
+
+    const json = (body: unknown, status = 200) =>
+      route.fulfill({status, json: body});
+    const noContent = () => route.fulfill({status: 204, body: ''});
+
+    if (path === 'server' && method === 'GET') {
+      return json({
+        name: this.name,
+        metricsEnabled: this.metricsEnabled,
+        serverId: 'fake-server-id',
+        createdTimestampMs: 1704067200000, // 2024-01-01T00:00:00Z
+        portForNewAccessKeys: 9999,
+        hostnameForAccessKeys: 'fake-shadowbox.invalid',
+        version: this.version,
+      });
+    }
+    if (path === 'name' && method === 'PUT') {
+      this.name = request.postDataJSON().name;
+      return noContent();
+    }
+    if (path === 'access-keys' && method === 'GET') {
+      return json({accessKeys: this.keys});
+    }
+    if (path === 'access-keys' && method === 'POST') {
+      return json(this.createKey(), 201);
+    }
+    const keyNameMatch = path.match(/^access-keys\/([^/]+)\/name$/);
+    if (keyNameMatch && method === 'PUT') {
+      const key = this.keys.find(k => k.id === keyNameMatch[1]);
+      if (!key) {
+        return json({message: 'not found'}, 404);
+      }
+      key.name = new URLSearchParams(request.postData() ?? '').get('name');
+      return noContent();
+    }
+    const keyMatch = path.match(/^access-keys\/([^/]+)$/);
+    if (keyMatch && method === 'DELETE') {
+      const index = this.keys.findIndex(k => k.id === keyMatch[1]);
+      if (index < 0) {
+        return json({message: 'not found'}, 404);
+      }
+      this.keys.splice(index, 1);
+      return noContent();
+    }
+    if (path === 'metrics/transfer' && method === 'GET') {
+      return json({bytesTransferredByUserId: this.bytesTransferredByKeyId});
+    }
+    if (path.startsWith('experimental/server/metrics')) {
+      // Not supported by this fake: the app falls back to /metrics/transfer.
+      return json({message: 'not found'}, 404);
+    }
+    if (path === 'metrics/enabled' && method === 'PUT') {
+      this.metricsEnabled = request.postDataJSON().metricsEnabled;
+      return noContent();
+    }
+    if (path === 'server/hostname-for-access-keys' && method === 'PUT') {
+      return noContent();
+    }
+    if (path === 'server/port-for-new-access-keys' && method === 'PUT') {
+      return noContent();
+    }
+    console.warn(`FakeShadowbox: unhandled request ${method} ${path}`);
+    return json({message: `unhandled: ${method} ${path}`}, 404);
+  }
+}

--- a/server_manager/e2e/tests/helpers.ts
+++ b/server_manager/e2e/tests/helpers.ts
@@ -1,0 +1,111 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type {Page} from '@playwright/test';
+
+import type {FakeShadowbox} from './fake_shadowbox';
+import englishMessages from '../../messages/en.json';
+
+/** The version reported by the app under test (see `loadApp`). */
+export const TEST_APP_VERSION = '0.0.0-e2e';
+
+/**
+ * Returns the app's own English message for the given key, so toast/text
+ * assertions track wording changes instead of hardcoding strings. Supports
+ * simple ICU-style `{placeholder}` substitution.
+ */
+export function englishMessage(
+  key: keyof typeof englishMessages,
+  substitutions: Record<string, string> = {}
+): string {
+  let message: string = englishMessages[key];
+  for (const [name, value] of Object.entries(substitutions)) {
+    message = message.replace(`{${name}}`, value);
+  }
+  return message;
+}
+
+/**
+ * Loads the app with a clean localStorage.
+ *
+ * Unless `firstLaunch` is set, the terms-of-service acknowledgement and the
+ * per-server metrics opt-in prompt (a modal that would otherwise cover the
+ * server view) are pre-dismissed so tests can go straight to the behavior
+ * under test.
+ */
+export async function loadApp(
+  page: Page,
+  {firstLaunch = false}: {firstLaunch?: boolean} = {}
+): Promise<void> {
+  if (!firstLaunch) {
+    await page.addInitScript(() => {
+      if (!window.localStorage.getItem('tos-ack')) {
+        window.localStorage.setItem('tos-ack', String(Date.now()));
+      }
+      // Key format: `${serverId}-prompted-for-metrics` (see
+      // App.showMetricsOptInWhenNeeded); FakeShadowbox always reports
+      // serverId 'fake-server-id'.
+      window.localStorage.setItem(
+        'fake-server-id-prompted-for-metrics',
+        'true'
+      );
+    });
+  }
+  await page.goto(`/?version=${TEST_APP_VERSION}`);
+}
+
+/** The `app-root` element (everything else lives in its shadow DOM). */
+export function appRoot(page: Page) {
+  return page.locator('app-root');
+}
+
+/** The intro page's provider cards ("choose a cloud provider" screen). */
+export function introPage(page: Page) {
+  return appRoot(page).locator('#intro');
+}
+
+/** The server management view for the currently selected server. */
+export function serverView(page: Page) {
+  return appRoot(page).locator('outline-server-view');
+}
+
+/**
+ * Adds `fake` as a manual server through the real UI flow: intro →
+ * "set up on your own server" → paste config → done.
+ *
+ * The fake must already be installed on the page (`fake.install(page)`).
+ */
+export async function addManualServer(
+  page: Page,
+  fake: FakeShadowbox
+): Promise<void> {
+  await introPage(page).locator('#manual-server').click();
+  const manualEntry = appRoot(page).locator('#manualEntry');
+  await manualEntry
+    .locator('#serverConfig')
+    .locator('textarea')
+    .fill(fake.config);
+  await manualEntry.locator('#doneButton').click();
+  await serverView(page).waitFor();
+}
+
+/** Rows of the access key table in the server view. */
+export function accessKeyRows(page: Page) {
+  return serverView(page).locator('access-key-data-table tbody tr');
+}
+
+/** Asserts against the app's toast element. */
+export function toast(page: Page) {
+  return appRoot(page).locator('#toast');
+}

--- a/server_manager/e2e/tests/keys.spec.ts
+++ b/server_manager/e2e/tests/keys.spec.ts
@@ -1,0 +1,107 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Key management (Key) checklist items, exercised against a manual server.
+// The DigitalOcean/GCP halves of these items are covered when the
+// provider flows are automated (see docs/manager-qa-automation-plan.md).
+// Test titles reference the QA checklist IDs.
+
+import {test, expect} from '@playwright/test';
+
+import {FakeShadowbox} from './fake_shadowbox';
+import {
+  accessKeyRows,
+  addManualServer,
+  englishMessage,
+  loadApp,
+  serverView,
+  toast,
+} from './helpers';
+
+test('Key.Add: user can add multiple keys to a server', async ({page}) => {
+  const fake = new FakeShadowbox();
+  await fake.install(page);
+  await loadApp(page);
+  await addManualServer(page, fake);
+  await expect(accessKeyRows(page)).toHaveCount(1);
+
+  const addKeyButton = serverView(page).locator('#addAccessKeyButton');
+  await addKeyButton.click();
+  await expect(toast(page)).toContainText(
+    englishMessage('notification-key-added')
+  );
+  await addKeyButton.click();
+
+  await expect(accessKeyRows(page)).toHaveCount(3);
+
+  // The keys must survive a restart (they live on the server).
+  await page.reload();
+  await serverView(page).waitFor();
+  await expect(accessKeyRows(page)).toHaveCount(3);
+});
+
+test('Key.Delete: user can delete an existing key from a server', async ({
+  page,
+}) => {
+  const fake = new FakeShadowbox();
+  await fake.install(page);
+  await loadApp(page);
+  await addManualServer(page, fake);
+  await serverView(page).locator('#addAccessKeyButton').click();
+  await expect(accessKeyRows(page)).toHaveCount(2);
+
+  const secondRow = accessKeyRows(page).nth(1);
+  await secondRow.getByTestId('access-key-menu-button').click();
+  await secondRow.getByTestId('access-key-delete-menu-item').click();
+
+  await expect(toast(page)).toContainText(
+    englishMessage('notification-key-removed')
+  );
+  await expect(accessKeyRows(page)).toHaveCount(1);
+});
+
+test('Key.Share: the access key is displayed so it can be shared with Outline Client', async ({
+  page,
+}) => {
+  const fake = new FakeShadowbox();
+  await fake.install(page);
+  await loadApp(page);
+  await addManualServer(page, fake);
+
+  await accessKeyRows(page)
+    .first()
+    .getByTestId('access-key-share-button')
+    .click();
+
+  const shareDialog = page.locator('outline-share-dialog');
+  await expect(shareDialog.locator('#dialog')).toBeVisible();
+  // Whether this key actually admits a client connection is covered by the
+  // real-Shadowbox layer of the plan; here we assert the exact key the
+  // server issued is what gets shared.
+  await expect(shareDialog.locator('#selectableAccessKey')).toContainText(
+    fake.listKeys()[0].accessUrl
+  );
+});
+
+test('Key.UsageData: per-key usage data is displayed', async ({page}) => {
+  const fake = new FakeShadowbox({
+    // 10^9 bytes for the server's first key: formatted as "1 GB".
+    bytesTransferredByKeyId: {'0': 10 ** 9},
+  });
+  await fake.install(page);
+  await loadApp(page);
+  await addManualServer(page, fake);
+
+  await expect(accessKeyRows(page).first()).toContainText('1 GB');
+});

--- a/server_manager/e2e/tests/server.spec.ts
+++ b/server_manager/e2e/tests/server.spec.ts
@@ -1,0 +1,112 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// App lifecycle (App) and server creation/connection/destruction
+// (ServerCreate, ServerConnect, ServerDestroy) checklist items.
+// Test titles reference the QA checklist IDs in
+// docs/manager-qa-automation-plan.md.
+
+import {test, expect} from '@playwright/test';
+
+import {FakeShadowbox} from './fake_shadowbox';
+import {
+  addManualServer,
+  appRoot,
+  englishMessage,
+  introPage,
+  loadApp,
+  serverView,
+  toast,
+} from './helpers';
+
+test('App.Start: first launch shows the Terms of Service, then the intro page', async ({
+  page,
+}) => {
+  await loadApp(page, {firstLaunch: true});
+
+  const acceptButton = appRoot(page).getByTestId('tos-accept-button');
+  await expect(acceptButton).toBeVisible();
+  await acceptButton.click();
+
+  await expect(introPage(page).locator('#manual-server')).toBeVisible();
+
+  // The acknowledgement must persist across restarts.
+  await page.reload();
+  await expect(introPage(page).locator('#manual-server')).toBeVisible();
+  await expect(acceptButton).not.toBeVisible();
+});
+
+test('ServerCreate.Manual: user can set up a server using advanced manual steps', async ({
+  page,
+}) => {
+  const fake = new FakeShadowbox({name: 'My Manual Server'});
+  await fake.install(page);
+  await loadApp(page);
+
+  await addManualServer(page, fake);
+
+  await expect(serverView(page)).toContainText('My Manual Server');
+  // A fresh Shadowbox comes with its first access key.
+  await expect(
+    serverView(page).locator('access-key-data-table tbody tr')
+  ).toHaveCount(1);
+});
+
+test('ServerConnect.Manual: manual servers are restored after a restart', async ({
+  page,
+}) => {
+  const fake = new FakeShadowbox({name: 'Persistent Server'});
+  await fake.install(page);
+  await loadApp(page);
+  await addManualServer(page, fake);
+
+  // "Restart the manager": the repository must reload the server from
+  // localStorage and reconnect to the management API.
+  await page.reload();
+  await serverView(page).waitFor();
+  await expect(serverView(page)).toContainText('Persistent Server');
+});
+
+test('ServerDestroy.Manual: user can remove a manual server', async ({
+  page,
+}) => {
+  const fake = new FakeShadowbox();
+  await fake.install(page);
+  await loadApp(page);
+  await addManualServer(page, fake);
+
+  // The overflow menu next to the server name offers "Remove server" for
+  // manual servers.
+  const view = serverView(page);
+  await view.locator('paper-icon-button[icon="more-vert"]').click();
+  await view
+    .locator('paper-item', {hasText: englishMessage('server-remove')})
+    .click();
+
+  // Confirm in the modal dialog.
+  await appRoot(page)
+    .locator('outline-modal-dialog paper-button', {
+      hasText: englishMessage('remove'),
+    })
+    .click();
+
+  await expect(toast(page)).toContainText(
+    englishMessage('notification-server-removed')
+  );
+  await expect(introPage(page).locator('#manual-server')).toBeVisible();
+
+  // The server must stay gone after a restart.
+  await page.reload();
+  await expect(introPage(page).locator('#manual-server')).toBeVisible();
+});

--- a/server_manager/e2e/tests/ui.spec.ts
+++ b/server_manager/e2e/tests/ui.spec.ts
@@ -1,0 +1,91 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Client UI (Ui) and error reporting (Report) checklist items.
+// Test titles reference the QA checklist IDs in
+// docs/manager-qa-automation-plan.md.
+
+import {test, expect} from '@playwright/test';
+
+import {
+  appRoot,
+  englishMessage,
+  loadApp,
+  TEST_APP_VERSION,
+  toast,
+} from './helpers';
+import spanishMessages from '../../messages/es.json';
+
+test('Ui.I18n: user can switch to another language, and it persists', async ({
+  page,
+}) => {
+  await loadApp(page);
+
+  const navAbout = appRoot(page).getByTestId('nav-about');
+  await expect(navAbout).toHaveText(englishMessage('nav-about'));
+
+  await appRoot(page).locator('#language-dropdown').click();
+  await appRoot(page)
+    .locator('#language-dropdown paper-item', {hasText: /^\s*Español\s*$/})
+    .click();
+
+  await expect(navAbout).toHaveText(spanishMessages['nav-about']);
+
+  // The language choice must persist across restarts.
+  await page.reload();
+  await expect(appRoot(page).getByTestId('nav-about')).toHaveText(
+    spanishMessages['nav-about']
+  );
+});
+
+// The full Ui.About accept criteria also require release builds to carry no
+// "-dev" version suffix; that half can only be checked against release
+// artifacts and belongs to the release-gate layer (this suite passes its own
+// version to the debug browser bundle).
+test('Ui.About (partial): about dialog shows the app version', async ({
+  page,
+}) => {
+  await loadApp(page);
+
+  await appRoot(page).getByTestId('nav-about').click();
+
+  const aboutDialog = appRoot(page).locator('outline-about-dialog');
+  await expect(aboutDialog.locator('#dialog')).toBeVisible();
+  await expect(aboutDialog.locator('#version')).toContainText(TEST_APP_VERSION);
+});
+
+// The browser build initializes Sentry without a DSN, so no feedback request
+// leaves the app; this asserts the UI half (form submits and confirms).
+// Intercepting the actual Sentry envelope needs the @sentry/browser split
+// (issue #1311) and is tracked in docs/manager-qa-automation-plan.md.
+test('Report.UserFeedback (partial): user can submit feedback', async ({
+  page,
+}) => {
+  await loadApp(page);
+
+  await appRoot(page).getByTestId('nav-feedback').click();
+
+  const feedbackDialog = appRoot(page).locator('outline-feedback-dialog');
+  await expect(feedbackDialog.locator('#dialog')).toBeVisible();
+  await feedbackDialog
+    .locator('#userFeedback')
+    .locator('textarea')
+    .fill('E2E test feedback: please ignore.');
+  await feedbackDialog.getByTestId('feedback-submit-button').click();
+
+  await expect(toast(page)).toContainText(
+    englishMessage('notification-feedback-thanks')
+  );
+  await expect(feedbackDialog.locator('#dialog')).not.toBeVisible();
+});

--- a/server_manager/e2e/tsconfig.json
+++ b/server_manager/e2e/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "include": ["playwright.config.ts", "test.action.mjs", "tests"],
+  "exclude": ["node_modules"]
+}

--- a/server_manager/e2e/tsconfig.json
+++ b/server_manager/e2e/tsconfig.json
@@ -5,6 +5,6 @@
     "esModuleInterop": true,
     "resolveJsonModule": true
   },
-  "include": ["playwright.config.ts", "test.action.mjs", "tests"],
+  "include": ["playwright.config.ts", "tests"],
   "exclude": ["node_modules"]
 }

--- a/server_manager/package.json
+++ b/server_manager/package.json
@@ -89,6 +89,7 @@
     "PUPPETEER_CHROMIUM_REVISION": 1274542
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@types/node": "^16.11.29",
     "@types/node-forge": "^1.0.2",
     "@types/polymer": "^1.2.9",
@@ -105,6 +106,7 @@
     "gulp-posthtml": "^3.0.4",
     "gulp-replace": "^1.0.0",
     "html-webpack-plugin": "^5.5.3",
+    "http-server": "^14.1.1",
     "jasmine": "^5.1.0",
     "karma": "^6.3.16",
     "karma-chrome-launcher": "^3.1.0",

--- a/server_manager/tsconfig.json
+++ b/server_manager/tsconfig.json
@@ -16,5 +16,5 @@
   },
   "rootDir": ".",
   "include": ["**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "e2e"]
 }

--- a/server_manager/www/ui_components/app-root.ts
+++ b/server_manager/www/ui_components/app-root.ts
@@ -404,14 +404,14 @@ export class AppRoot extends polymerElementWithLocalize {
                 <iron-icon id="open-in-new-icon" icon="open-in-new" />
               </a>
             </span>
-            <span on-tap="submitFeedbackTapped">[[localize('nav-feedback')]]</span>
+            <span on-tap="submitFeedbackTapped" data-testid="nav-feedback">[[localize('nav-feedback')]]</span>
             <span on-tap="maybeCloseDrawer">
               <a href="https://support.getoutline.org">
                 <span>[[localize('nav-help')]]</span>
                 <iron-icon id="open-in-new-icon" icon="open-in-new" />
               </a>
             </span>
-            <span on-tap="aboutTapped">[[localize('nav-about')]]</span>
+            <span on-tap="aboutTapped" data-testid="nav-about">[[localize('nav-about')]]</span>
             <div id="links-footer">
               <paper-icon-item id="language-row">
                 <iron-icon id="language-icon" icon="language" slot="item-icon"></iron-icon>

--- a/server_manager/www/ui_components/outline-feedback-dialog.ts
+++ b/server_manager/www/ui_components/outline-feedback-dialog.ts
@@ -159,7 +159,10 @@ Polymer({
       <!-- end of #feedbackWrapper -->
       <p class="buttons">
         <paper-button dialog-dismiss="">[[localize('cancel')]]</paper-button>
-        <paper-button autofocus="" on-tap="submitTappedHandler"
+        <paper-button
+          autofocus=""
+          on-tap="submitTappedHandler"
+          data-testid="feedback-submit-button"
           >[[localize('feedback-submit')]]</paper-button
         >
       </p>

--- a/server_manager/www/ui_components/outline-tos-view.ts
+++ b/server_manager/www/ui_components/outline-tos-view.ts
@@ -56,7 +56,9 @@ Polymer({
       <span
         inner-h-t-m-l="[[localize('terms-of-service', 'openLink', '<a href=https://getoutline.org/policies/terms-of-service>', 'closeLink', '</a>')]]"
       ></span>
-      <paper-button on-tap="acceptTermsOfService"
+      <paper-button
+        on-tap="acceptTermsOfService"
+        data-testid="tos-accept-button"
         >[[localize('okay')]]</paper-button
       >
     </div>

--- a/server_manager/www/views/server_view/access_key_data_table/access_key_controls/index.ts
+++ b/server_manager/www/views/server_view/access_key_data_table/access_key_controls/index.ts
@@ -84,22 +84,35 @@ export class AccessKeyControls extends LitElement {
   render() {
     return html`
       <span class="wrapper">
-        <mwc-icon-button icon="share" @click=${this.share}></mwc-icon-button>
+        <mwc-icon-button
+          icon="share"
+          data-testid="access-key-share-button"
+          @click=${this.share}
+        ></mwc-icon-button>
         <span class="menu-wrapper">
           <mwc-icon-button
             icon="more_vert"
             id="menuButton"
+            data-testid="access-key-menu-button"
             @click=${() => {
               this.menu.anchor = this.menuButton;
               this.menu.show();
             }}
           ></mwc-icon-button>
           <mwc-menu id="menu">
-            <mwc-list-item @click=${this.editName} graphic="icon">
+            <mwc-list-item
+              data-testid="access-key-rename-menu-item"
+              @click=${this.editName}
+              graphic="icon"
+            >
               <mwc-icon slot="graphic">create</mwc-icon>
               ${this.localize('server-access-key-rename')}
             </mwc-list-item>
-            <mwc-list-item @click=${this.delete} graphic="icon">
+            <mwc-list-item
+              data-testid="access-key-delete-menu-item"
+              @click=${this.delete}
+              graphic="icon"
+            >
               <mwc-icon slot="graphic">delete</mwc-icon>
               ${this.localize('remove')}
             </mwc-list-item>


### PR DESCRIPTION
## Summary

Manager counterpart of #2796: first slice of the automated QA suite described in `docs/manager-qa-automation-plan.md` (included in this PR) — the plan itself, testability groundwork, and Layer 1, a Playwright suite that drives the real Manager web UI in a browser on every PR.

- **Plan**: `docs/manager-qa-automation-plan.md` maps the manual Manager QA checklist ([go/outlinevpn-manager-qa](http://go/outlinevpn-manager-qa)) to five automation layers, with a phased rollout and status checklist. Same layering and traceability conventions as the client plan.
- **Key insight**: manual servers added without a certificate fingerprint use plain `window.fetch`, so Playwright's `page.route()` can impersonate a complete Shadowbox management API (`server_manager/e2e/tests/fake_shadowbox.ts`) while the app runs 100% real code — repository, `localStorage` persistence, and UI. No fake objects are injected; "restart the manager" checklist steps become `page.reload()`.
- **Groundwork**: `data-testid` attributes on the TOS accept button, nav feedback/about items, feedback submit button, and access-key controls (share/menu/rename/delete); `server_manager/e2e` excluded from the manager tsconfig so the Playwright specs don't leak into the Jasmine/Karma runs.
- **Playwright suite** (`server_manager/e2e`, `npm run action server_manager/e2e/test`): runs against the existing browser build (`browser.webpack.js`). Test titles carry the QA checklist IDs they automate: App.Start, ServerCreate.Manual, ServerConnect.Manual, ServerDestroy.Manual, Key.Add (+persistence), Key.Delete, Key.Share (UI half), Key.UsageData, Ui.I18n (+persistence), Ui.About (partial), Report.UserFeedback (UI half — the browser build initializes Sentry without a DSN until #1311, so there's no outgoing request to intercept yet).
- **CI**: new `manager_ui_e2e_test` job in Build and Test / Manager; uploads the Playwright report on failure.

DigitalOcean/GCP flows against intercepted provider APIs, the real-Shadowbox container layer, Electron E2E, and the cloud canary are next phases in the plan.

## Test plan

- `npm run action server_manager/e2e/test` — 11/11 passing locally (~5s after build)
- `npm run action server_manager/test` — existing suite still green (59/59 Karma + node Jasmine)
- `npm run lint:gts` clean on all changed TS files
- New CI job on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)