### PR TITLE
test(client): run the Electron E2E suite on Windows

### DIFF
--- a/.github/workflows/build_and_test_debug_client.yml
+++ b/.github/workflows/build_and_test_debug_client.yml
@@ -153,6 +153,51 @@ jobs:
           path: client/e2e/playwright-report-electron/
           retention-days: 7
 
+  windows_electron_e2e_test:
+    name: Windows Electron E2E Test
+    # windows-2022 instead of windows-2025 for the same node-gyp reason as
+    # the Windows debug builds below.
+    runs-on: windows-2022
+    timeout-minutes: 40
+    steps:
+      - name: Support longpaths
+        run: git config --system core.longpaths true
+
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: ./package-lock.json
+
+      - name: Install NPM Dependencies
+        run: npm ci
+
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: '${{ github.workspace }}/go.mod'
+
+      - name: Install zig
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: 0.13.0
+          use-cache: false
+
+      - name: Run Electron E2E Suite
+        run: npm run action client/e2e/electron/test
+
+      - name: Upload Playwright Report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-electron-windows
+          path: client/e2e/playwright-report-electron/
+          retention-days: 7
+
   electron_debug_build:
     name: ${{ matrix.name }} Debug Build
     runs-on: ${{ matrix.runner }}
@@ -357,6 +402,7 @@ jobs:
       [
         shared_ui_e2e_test,
         electron_e2e_test,
+        windows_electron_e2e_test,
         electron_debug_build,
         macos_debug_build,
         ios_debug_build,

--- a/client/build/get_build_parameters.mjs
+++ b/client/build/get_build_parameters.mjs
@@ -33,6 +33,10 @@ export const SUPPORTED_BUILDS = [
   {platform: 'linux', arch: 'arm64', goArch: 'arm64'},
   {platform: 'windows', arch: 'ia32', goArch: '386'},
   {platform: 'windows', arch: 'arm64', goArch: 'arm64'},
+  // The shipped Windows installers are ia32/arm64 (above); x64 exists for
+  // the Electron E2E suite, which runs the x64 dev Electron binary on x64
+  // CI runners and needs a matching backend.dll to load.
+  {platform: 'windows', arch: 'x64', goArch: 'amd64'},
 ];
 
 const BUILDS_BY_PLATFORM = Map.groupBy(SUPPORTED_BUILDS, b => b.platform);

--- a/client/e2e/README.md
+++ b/client/e2e/README.md
@@ -7,9 +7,10 @@ Playwright suites from the automated QA plan
   Capacitor browser build) against the browser method channel and the fake
   VPN API.
 - **Electron desktop suite** (`electron/`, Layer 3): launches the real
-  Electron app — main process, preload, Go backend over koffi, real renderer
-  — with Playwright's `_electron` driver. Linux-only (the Electron client
-  does not run on macOS); runs in CI on ubuntu:
+  Electron app — main process, preload, Go backend over koffi (libbackend.so
+  on Linux, backend.dll on Windows), real renderer — with Playwright's
+  `_electron` driver. Linux and Windows only (the Electron client does not
+  run on macOS); runs in CI on ubuntu and windows runners:
 
   ```sh
   npm run action client/e2e/electron/test

--- a/client/e2e/electron/prepare_app.mjs
+++ b/client/e2e/electron/prepare_app.mjs
@@ -22,22 +22,26 @@ import {runAction} from '@outline/infrastructure/build/run_action.mjs';
 import {stageRuntimeAssets} from '../../electron/stage_runtime_assets.mjs';
 
 /**
- * Builds the Electron app for the current Linux architecture and stages every
- * runtime asset the unpackaged launch needs, exactly as a packaged build
- * would lay them out. Shared by the Electron E2E test actions.
+ * Builds the Electron app for the current platform and architecture and
+ * stages every runtime asset the unpackaged launch needs, exactly as a
+ * packaged build would lay them out. Shared by the Electron E2E test
+ * actions. Linux and Windows only — the platforms the Electron client
+ * supports.
  *
  * @returns {Promise<string>} Absolute path to the launchable app directory.
  */
 export async function prepareElectronApp() {
+  const platform = os.platform() === 'win32' ? 'windows' : 'linux';
   // Node's os.arch() values ('x64', 'arm64') match the --arch values the
   // build actions accept; the Go toolchain names them differently.
   const arch = os.arch();
   const goArch = {x64: 'amd64', arm64: 'arm64', ia32: '386'}[arch] ?? arch;
 
-  // Compiles libbackend.so + tun2socks for the current linux arch.
-  await runAction('client/go/build', 'linux', `--arch=${arch}`);
+  // Compiles the backend library (libbackend.so / backend.dll) + tun2socks
+  // for the current platform and arch.
+  await runAction('client/go/build', platform, `--arch=${arch}`);
   // Builds the web UI and webpacks the Electron main process + preload.
-  await runAction('client/electron/build_main', 'linux', `--arch=${arch}`);
+  await runAction('client/electron/build_main', platform, `--arch=${arch}`);
 
   const appPath = path.join(getRootDir(), 'output', 'client', 'electron');
 
@@ -46,11 +50,12 @@ export async function prepareElectronApp() {
   // action does (this build skips electron-builder packaging).
   await stageRuntimeAssets(appPath);
 
-  // Stage the Go backend (libbackend.so + tun2socks) at the path
+  // Stage the Go backend (backend library + tun2socks) at the path
   // app_paths.ts#pathToBackendLibrary resolves it: <appPath>/output/client/
-  // linux-<goArch>. In a packaged build electron-builder bundles this dir; the
-  // unpackaged E2E launch has to mirror it so the real backend loads.
-  const backendDir = path.join('output', 'client', `linux-${goArch}`);
+  // <platform>-<goArch>. In a packaged build electron-builder bundles this
+  // dir; the unpackaged E2E launch has to mirror it so the real backend
+  // loads.
+  const backendDir = path.join('output', 'client', `${platform}-${goArch}`);
   await fs.cp(
     path.join(getRootDir(), backendDir),
     path.join(appPath, backendDir),

--- a/client/e2e/electron/test.action.mjs
+++ b/client/e2e/electron/test.action.mjs
@@ -22,25 +22,29 @@ import {spawnStream} from '@outline/infrastructure/build/spawn_stream.mjs';
 import {prepareElectronApp} from './prepare_app.mjs';
 
 /**
- * @description Builds the Electron app for Linux and runs the desktop E2E
- * suite (Playwright _electron) against it. Extra parameters are forwarded to
- * `playwright test`. Linux-only: the Electron client does not run on macOS.
+ * @description Builds the Electron app for the current platform and runs the
+ * desktop E2E suite (Playwright _electron) against it. Extra parameters are
+ * forwarded to `playwright test`. Linux and Windows only: the Electron
+ * client does not run on macOS.
  *
  * @param {string[]} parameters
  */
 export async function main(...parameters) {
-  if (os.platform() !== 'linux') {
+  if (os.platform() !== 'linux' && os.platform() !== 'win32') {
     throw new Error(
-      'The Electron E2E suite only runs on Linux (the Electron client ' +
-        'does not support macOS). It runs in CI on ubuntu runners.'
+      'The Electron E2E suite only runs on Linux and Windows (the Electron ' +
+        'client does not support macOS). It runs in CI on ubuntu and ' +
+        'windows runners.'
     );
   }
 
   await prepareElectronApp();
 
+  // Invoke the Playwright CLI through node rather than `npx`: spawning the
+  // `npx` .cmd shim without a shell fails on Windows.
   await spawnStream(
-    'npx',
-    'playwright',
+    process.execPath,
+    path.join(getRootDir(), 'node_modules', '@playwright', 'test', 'cli.js'),
     'test',
     '--config',
     path.join(getRootDir(), 'client', 'e2e', 'electron.playwright.config.ts'),

--- a/docs/qa-automation-plan.md
+++ b/docs/qa-automation-plan.md
@@ -193,7 +193,13 @@ explicitly.
         is verified as traffic recovery after an interface bounce plus
         reconnect-on-launch after an unclean shutdown — no transient
         "reconnecting" UI state exists on Linux for network drops.
-  - [ ] Playwright Electron on Windows
+  - [x] Playwright Electron on Windows, UI level against the real app + Go
+        backend (the same `client/e2e/electron` suite, loading the real
+        backend.dll; runs in the `windows_electron_e2e_test` CI job on
+        windows-2022). Real-tunnel Windows (TAP device + OutlineService)
+        stays on the nightly/release-gate tier, mirroring the Linux split.
+  - [ ] Playwright Electron on Windows — real tunnel (TAP + OutlineService
+        install; nightly/gated job)
   - [ ] Windows installer/signature scripts on the release gate
 - [ ] **Phase 3 — Android**
   - [ ] Maestro flows on emulator in nightly CI (real VPN + Net.Web)


### PR DESCRIPTION
Part of the automated QA plan (docs/qa-automation-plan.md, Phase 2 / Layer 3). Stacked on #2803.

Runs the existing UI-level Electron desktop E2E suite (`client/e2e/electron/app.spec.ts` — **App.Start**, **Vpn.AddKey**, **Vpn.AddKey.InvalidKey** through the real Go `ParseTunnelConfig`, **App.Terminate**) on a `windows-2022` runner, validating that the real Windows backend (`backend.dll`, loaded over koffi per `app_paths.ts#pathToBackendLibrary`) works end to end with the real main process, preload, and renderer.

## Changes

- `client/e2e/electron/prepare_app.mjs` + `test.action.mjs` are now cross-platform: they build `client/go` and the Electron main process for the current platform and stage the backend at `output/client/windows-<goArch>` (`backend.dll` + `tun2socks.exe`) exactly where the app resolves it.
- `SUPPORTED_BUILDS` gains a `windows/x64` entry: shipped installers remain ia32/arm64, but the E2E suite runs the x64 dev Electron binary on x64 runners and needs a matching x64 `backend.dll` (a 32-bit dll can't load into an x64 process).
- The Playwright CLI is invoked via `node .../@playwright/test/cli.js` instead of `npx`, whose `.cmd` shim can't be spawned without a shell on Windows.
- New `windows_electron_e2e_test` per-PR job (no xvfb needed on Windows; GUI sessions work on hosted Windows runners).

## Scope note

This is the UI-level tier only, mirroring how Linux is split: real-tunnel Windows coverage (TAP device + `OutlineService` install) is left for the nightly/release-gate tier, tracked as a remaining item in the plan doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)