### PR TITLE
test(client/android): Maestro Android E2E smoke on emulator (QA plan Layer 4)

### DIFF
--- a/.github/workflows/nightly_android_e2e.yml
+++ b/.github/workflows/nightly_android_e2e.yml
@@ -1,0 +1,106 @@
+# Copyright 2026 The Outline Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Layer 4 (QA plan): Android native-seam smoke on a real emulator — deep-link
+# add-key, real VpnService tunnel to a hermetic local Shadowsocks server,
+# consent dialog, disconnect. Driven by Maestro through the accessibility
+# tree (validated by the 2026-07 spike; see client/e2e/android/README.md).
+
+name: Nightly Android E2E
+
+concurrency:
+  group: '${{ github.head_ref || github.ref }} Android E2E'
+  cancel-in-progress: true
+
+on:
+  schedule:
+    - cron: '0 14 * * *' # Daily at 2PM UTC, after the 1PM debug build.
+  workflow_dispatch:
+
+jobs:
+  android_e2e:
+    name: Android Emulator E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: ./package-lock.json
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: '${{ github.workspace }}/go.mod'
+
+      - name: Setup Java
+        run: echo "JAVA_HOME=$JAVA_HOME_17_X64" >> $GITHUB_ENV
+
+      - name: Install NPM Dependencies
+        run: npm ci
+
+      - name: Build Android Client
+        run: npm run action client/src/cordova/build android -- --verbose
+
+      - name: Start Hermetic Shadowsocks Server
+        working-directory: client/go/e2etest
+        # The emulator reaches the host's loopback via 10.0.2.2.
+        run: |
+          go build -o /tmp/ss-server ./cmd/ss-server
+          nohup /tmp/ss-server -port 18388 -secret e2e-test-secret > /tmp/ss-server.log 2>&1 &
+
+      - name: Install Maestro
+        run: |
+          curl -fsSL "https://get.maestro.mobile.dev" | bash
+          echo "$HOME/.maestro/bin" >> $GITHUB_PATH
+
+      - name: Run Maestro Flows on Emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 35
+          arch: x86_64
+          target: default
+          disable-animations: true
+          emulator-options: -no-window -no-audio -no-boot-anim -no-snapshot -camera-back none
+          script: |
+            adb install client/platforms/android/app/build/outputs/apk/debug/app-debug.apk
+            SS_URL="ss://$(printf 'chacha20-ietf-poly1305:e2e-test-secret' | basenc --base64url | tr -d '=')@10.0.2.2:18388/#E2E"
+            maestro test -e SS_URL="$SS_URL" --debug-output maestro-debug client/e2e/android/flows/
+
+      - name: Assert Tunnel Traffic Reached the Shadowsocks Server (Net.Web)
+        run: |
+          cat /tmp/ss-server.log
+          grep -q "tcp connection from" /tmp/ss-server.log
+
+      - name: Upload Maestro Artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: maestro-debug-output
+          path: |
+            maestro-debug
+            /tmp/ss-server.log
+          if-no-files-found: ignore

--- a/.github/workflows/nightly_android_e2e.yml
+++ b/.github/workflows/nightly_android_e2e.yml
@@ -27,6 +27,13 @@ on:
   schedule:
     - cron: '0 14 * * *' # Daily at 2PM UTC, after the 1PM debug build.
   workflow_dispatch:
+  # Also run when the Android E2E assets themselves change, so PRs like the
+  # one introducing this suite validate it without waiting for a nightly.
+  pull_request:
+    paths:
+      - .github/workflows/nightly_android_e2e.yml
+      - client/e2e/android/**
+      - client/go/e2etest/**
 
 jobs:
   android_e2e:

--- a/.github/workflows/nightly_android_e2e.yml
+++ b/.github/workflows/nightly_android_e2e.yml
@@ -78,6 +78,7 @@ jobs:
         run: |
           go build -o /tmp/ss-server ./cmd/ss-server
           nohup /tmp/ss-server -port 18388 -secret e2e-test-secret > /tmp/ss-server.log 2>&1 &
+          echo "SS_URL=ss://$(printf 'chacha20-ietf-poly1305:e2e-test-secret' | basenc --base64url | tr -d '=')@10.0.2.2:18388/#E2E" >> "$GITHUB_ENV"
 
       - name: Install Maestro
         run: |
@@ -92,10 +93,11 @@ jobs:
           target: default
           disable-animations: true
           emulator-options: -no-window -no-audio -no-boot-anim -no-snapshot -camera-back none
+          # Each script line runs as its own `sh -c`, so no state (like shell
+          # variables) survives between lines; SS_URL comes in via GITHUB_ENV.
           script: |
             adb install client/platforms/android/app/build/outputs/apk/debug/app-debug.apk
-            SS_URL="ss://$(printf 'chacha20-ietf-poly1305:e2e-test-secret' | basenc --base64url | tr -d '=')@10.0.2.2:18388/#E2E"
-            maestro test -e SS_URL="$SS_URL" --debug-output maestro-debug client/e2e/android/flows/
+            maestro test -e SS_URL="$SS_URL" --debug-output "$GITHUB_WORKSPACE/maestro-debug" client/e2e/android/flows/
 
       - name: Assert Tunnel Traffic Reached the Shadowsocks Server (Net.Web)
         run: |

--- a/client/e2e/android/README.md
+++ b/client/e2e/android/README.md
@@ -1,0 +1,66 @@
+# Android E2E (Layer 4 — native seams)
+
+Maestro flows that exercise what only a real Android OS can: the `ss://`
+deep-link intent, the real `VpnService` tunnel, the OS VPN-consent dialog, and
+disconnect. UI behavior is owned by the shared-UI Playwright suite
+([client/e2e](../)); these flows deliberately stay off that turf.
+
+They run nightly in CI on an emulator
+([nightly_android_e2e.yml](../../../.github/workflows/nightly_android_e2e.yml))
+against the hermetic Shadowsocks server in
+[client/go/e2etest/cmd/ss-server](../../go/e2etest/cmd/ss-server), which the
+emulator reaches on the host's loopback via `10.0.2.2`. `Net.Web` is asserted
+server-side: the client's connectivity probes only show up in the ss-server
+log if the tunnel is actually up.
+
+## Spike findings (2026-07) — why Maestro, and the sharp edges
+
+The driver decision (Maestro vs. Appium hybrid) hinged on whether the Cordova
+webview's Polymer/Lit content is visible through the accessibility tree.
+Verified on emulators (API 35 default and API 36.1 Play images):
+
+- **Webview button text IS in the a11y tree** — `Connect`, `Disconnect`,
+  `Confirm`, `Got It`, server names and addresses are all visible and tappable
+  by text. No accessibility labels needed for these flows (adding them is
+  still a worthwhile product improvement).
+- **CSS `text-transform` propagates to the a11y tree** (`CONNECT`), so flows
+  match case-insensitively: `"(?i)^connect$"`.
+- **Text is localized** — CI emulators default to `en-US`; pin the locale if
+  that ever changes.
+- **The `server-connection-indicator` is invisible to a11y** (pure SVG, no
+  text). Connection state is asserted via the button label flip plus
+  server-side traffic, which is stronger anyway.
+- **Two one-time dialogs need optional taps**: the first-run privacy notice
+  and the first-connect "Stay protected, always" tip (both webview, both
+  "Got It").
+- **The VPN consent dialog is a plain system alert** with an `OK` button;
+  Maestro taps it fine. Consent persists per-app until the app is
+  *uninstalled* (`pm clear` does not revoke it), so a true first-connect test
+  needs a fresh install.
+
+## Running locally
+
+```sh
+# 1. Hermetic Shadowsocks target (leave running)
+cd client/go/e2etest && go run ./cmd/ss-server -port 18388 -secret e2e-test-secret
+
+# 2. Build + install the debug client on a running emulator
+npm run action client/src/cordova/build android
+adb install -r client/platforms/android/app/build/outputs/apk/debug/app-debug.apk
+
+# 3. Run the flows (Maestro: https://maestro.mobile.dev)
+SS_URL="ss://$(printf 'chacha20-ietf-poly1305:e2e-test-secret' | base64 | tr -d '=' | tr '+/' '-_')@10.0.2.2:18388/#E2E"
+maestro test -e SS_URL="$SS_URL" client/e2e/android/flows/
+```
+
+For a full first-run (privacy notice + consent dialog), uninstall first:
+`adb uninstall org.outline.android.client`.
+
+## Open items
+
+- Validate the workflow on CI runners (spike ran on a local arm64 emulator;
+  CI uses x86_64 with KVM — expected to work, unproven).
+- `Vpn.AutoReconnect` flow (`adb shell svc wifi disable/enable`) — assess
+  emulator reliability before adding.
+- The Linux Electron real-tunnel branch (`qa-automation-electron-tunnel`) has
+  its own ss-server cmd staged; unify the two when it lands.

--- a/client/e2e/android/flows/vpn-smoke.yaml
+++ b/client/e2e/android/flows/vpn-smoke.yaml
@@ -1,0 +1,73 @@
+# Copyright 2026 The Outline Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Android native-seam smoke: real VpnService tunnel on the emulator.
+# Covers checklist IDs: Vpn.AddKey (via ss:// deep link), Vpn.Connect,
+# Vpn.Disconnect. Net.Web is asserted server-side: the hermetic Shadowsocks
+# server (client/go/e2etest/cmd/ss-server) logs the client's connectivity
+# probes, which only arrive if the tunnel is actually up.
+#
+# Requires SS_URL, e.g.:
+#   maestro test -e SS_URL='ss://<base64url(cipher:secret)>@10.0.2.2:18388/#Spike' vpn-smoke.yaml
+#
+# Matching notes (from the 2026-07 spike):
+# - The Cordova webview's button text IS exposed through the accessibility
+#   tree (no aria labels needed), but CSS text-transform uppercases it, so
+#   match case-insensitively.
+# - Text is localized; CI emulators default to en-US. Pin the locale if that
+#   ever changes.
+appId: org.outline.android.client
+name: android-vpn-smoke
+---
+- launchApp
+# First-run privacy notice (webview); absent on relaunch.
+- tapOn:
+    text: "(?i)got it"
+    optional: true
+# Vpn.AddKey — deep-link seam: the ss:// key opens the add-server dialog.
+- openLink: ${SS_URL}
+- extendedWaitUntil:
+    visible:
+      text: "(?i)^confirm$"
+    timeout: 15000
+- tapOn:
+    text: "(?i)^confirm$"
+# Vpn.Connect — webview button, then the native OS consent dialog
+# (first connect on a fresh device only).
+- extendedWaitUntil:
+    visible:
+      text: "(?i)^connect$"
+    timeout: 15000
+- tapOn:
+    text: "(?i)^connect$"
+- tapOn:
+    text: "(?i)^ok$"
+    optional: true
+# First-connect "Stay protected, always" tip covers the card; dismiss it.
+- tapOn:
+    text: "(?i)got it"
+    optional: true
+- extendedWaitUntil:
+    visible:
+      text: "(?i)^disconnect$"
+    timeout: 30000
+- takeScreenshot: vpn-connected
+# Vpn.Disconnect — back to the disconnected state.
+- tapOn:
+    text: "(?i)^disconnect$"
+- extendedWaitUntil:
+    visible:
+      text: "(?i)^connect$"
+    timeout: 20000
+- takeScreenshot: vpn-disconnected

--- a/client/go/e2etest/cmd/ss-server/main.go
+++ b/client/go/e2etest/cmd/ss-server/main.go
@@ -1,0 +1,89 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command ss-server runs a real outline-ss-server Shadowsocks service on a
+// fixed local port, as a hermetic tunnel target for device/emulator E2E runs
+// (the Android emulator reaches the host's loopback via 10.0.2.2). It mirrors
+// the in-process server used by the transport tests in this module.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"log/slog"
+	"net"
+	"os"
+	"time"
+
+	"golang.getoutline.org/sdk/transport"
+	"golang.getoutline.org/tunnel-server/service"
+)
+
+const cipherName = "chacha20-ietf-poly1305"
+
+func main() {
+	port := flag.Int("port", 18388, "TCP+UDP port to listen on")
+	secret := flag.String("secret", "e2e-test-secret", "Shadowsocks secret")
+	flag.Parse()
+
+	ciphers, err := service.MakeTestCiphers([]string{*secret})
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Allow all targets: the client's connectivity probes hit public
+	// addresses, and test echo targets live on loopback.
+	allowAll := func(net.IP) error { return nil }
+	streamHandler, associationHandler := service.NewShadowsocksHandlers(
+		service.WithCiphers(ciphers),
+		service.WithStreamDialer(service.MakeValidatingTCPStreamDialer(allowAll, 0)),
+		service.WithPacketListener(service.MakeTargetUDPListener(allowAll, 30*time.Second, 0)),
+		service.WithLogger(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))),
+	)
+
+	addr := fmt.Sprintf("127.0.0.1:%d", *port)
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		log.Fatal(err)
+	}
+	packetConn, err := net.ListenPacket("udp", addr)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("shadowsocks server listening on %s (tcp+udp), cipher=%s", addr, cipherName)
+
+	go service.PacketServe(packetConn, func(ctx context.Context, conn net.Conn) {
+		associationHandler.HandleAssociation(ctx, conn, &service.NoOpUDPAssociationMetrics{})
+	}, noopNATMetrics{})
+
+	service.StreamServe(
+		func() (transport.StreamConn, error) {
+			conn, err := listener.Accept()
+			if err != nil {
+				return nil, err
+			}
+			log.Printf("tcp connection from %s", conn.RemoteAddr())
+			return conn.(*net.TCPConn), nil
+		},
+		func(ctx context.Context, conn transport.StreamConn) {
+			streamHandler.HandleStream(ctx, conn, &service.NoOpTCPConnMetrics{})
+		},
+	)
+}
+
+type noopNATMetrics struct{}
+
+func (noopNATMetrics) AddNATEntry()    {}
+func (noopNATMetrics) RemoveNATEntry() {}

--- a/docs/qa-automation-plan.md
+++ b/docs/qa-automation-plan.md
@@ -198,8 +198,9 @@ explicitly.
   - [x] Maestro smoke flow (deep-link add-key, real VpnService connect,
         consent dialog, disconnect; Net.Web asserted via ss-server logs) —
         `client/e2e/android/flows/`
-  - [ ] Validate `nightly_android_e2e.yml` on CI runners (x86_64 emulator
-        under KVM; spike ran locally on arm64)
+  - [x] Validate `nightly_android_e2e.yml` on CI runners — green on
+        ubuntu-latest (x86_64 emulator under KVM, ~8 min end-to-end, real
+        tunnel traffic asserted server-side)
   - [ ] `Vpn.AutoReconnect` flow if emulator network toggling proves reliable
 - [ ] **Phase 4 — Apple platforms**
   - [ ] iOS simulator UI suite (mocked VPN)

--- a/docs/qa-automation-plan.md
+++ b/docs/qa-automation-plan.md
@@ -98,9 +98,12 @@ Covers: `App.Start`, `App.Terminate`, `Vpn.Connect`, `Vpn.Disconnect`,
   connect + `Net.Web` checks are automatable.
 - Deep links via `adb shell am start` / Maestro `openLink`.
 - `Vpn.AutoReconnect` via `adb shell svc wifi disable/enable`.
-- Spike required: Maestro sees webview content through the accessibility tree;
-  Cordova/Polymer content may need accessibility labels. Fallback: Appium
-  (UiAutomator2) with hybrid-context switching into the webview DOM.
+- ~~Spike required~~ **Spike done (2026-07): Maestro confirmed.** The webview's
+  button text is exposed through the accessibility tree as-is — no labeling
+  pass needed (text is uppercased by CSS and localized; flows match
+  case-insensitively in en-US). Full deep-link → consent → real tunnel →
+  disconnect cycle validated on emulator against the hermetic ss-server; see
+  `client/e2e/android/README.md`. Appium remains the documented fallback.
 
 **iOS — split UI tests from tunnel tests.** `NEPacketTunnelProvider` does not
 run on the iOS Simulator, so:
@@ -166,7 +169,9 @@ explicitly.
         add-key dialog, server cards, rename dialog)
   - [x] Hermetic Shadowsocks harness (`client/go/e2etest`: a real
         `tunnel-server` service running in-process on loopback)
-  - [ ] Maestro-on-Cordova-webview spike (Android)
+  - [x] Maestro-on-Cordova-webview spike (Android): webview text is
+        a11y-visible, full tunnel cycle automated locally — Maestro selected
+        (see `client/e2e/android/README.md`)
 - [ ] **Phase 1 — per-PR suites**
   - [x] Playwright shared-UI suite, tagged with checklist IDs
         (`client/e2e`; covers App.Start, Vpn.Default.Clean, Vpn.AddKey,
@@ -190,7 +195,12 @@ explicitly.
   - [ ] Playwright Electron on Windows
   - [ ] Windows installer/signature scripts on the release gate
 - [ ] **Phase 3 — Android**
-  - [ ] Maestro flows on emulator in nightly CI (real VPN + Net.Web)
+  - [x] Maestro smoke flow (deep-link add-key, real VpnService connect,
+        consent dialog, disconnect; Net.Web asserted via ss-server logs) —
+        `client/e2e/android/flows/`
+  - [ ] Validate `nightly_android_e2e.yml` on CI runners (x86_64 emulator
+        under KVM; spike ran locally on arm64)
+  - [ ] `Vpn.AutoReconnect` flow if emulator network toggling proves reliable
 - [ ] **Phase 4 — Apple platforms**
   - [ ] iOS simulator UI suite (mocked VPN)
   - [ ] macOS Catalyst XCUITest suite


### PR DESCRIPTION
Stacked on #2798 (QA automation stack: #2762 → #2796 → #2797 → #2798 → this).

## What this is

The Android driver spike for QA plan Layer 4 — and, since it passed, the first working slice of the Android native-seam suite. Scope per the Layer 4 design discussion: **native seams only** (deep links, real `VpnService` tunnel, OS consent dialog, disconnect); UI behavior stays in the Layer 1 Playwright suite.

## Spike result: Maestro confirmed, no fallback needed

The gating question was whether Maestro can see the Cordova webview's Polymer/Lit content through the accessibility tree. It can: `Connect` / `Disconnect` / `Confirm` button text, server names, and addresses are all exposed and tappable by text, with **zero accessibility-labeling changes** to the shared UI. Appium hybrid remains the documented fallback but is not needed.

Validated end-to-end on a pristine emulator (fresh install, so the real OS VPN-consent dialog appears):

1. `ss://` access key via deep link → add-server dialog → Confirm (webview)
2. CONNECT (webview) → OS VPN-consent dialog → OK (native)
3. Real `VpnService` tunnel establishes; the hermetic Shadowsocks server on the host (via `10.0.2.2`) logs the client's connectivity probes — the `Net.Web` assertion, made server-side
4. DISCONNECT → back to the disconnected state

Sharp edges found and documented in `client/e2e/android/README.md`: CSS `text-transform` uppercases a11y text (flows match case-insensitively), text is localized (en-US assumed), two one-time dialogs need optional taps, and VPN consent survives `pm clear` (only uninstall revokes it).

## What's included

- `client/e2e/android/flows/vpn-smoke.yaml` — the validated Maestro flow, tagged with checklist IDs (Vpn.AddKey, Vpn.Connect, Vpn.Disconnect; Net.Web server-side)
- `client/go/e2etest/cmd/ss-server/` — standalone hermetic Shadowsocks server mirroring the in-process one from #2797 (to be unified with the Electron real-tunnel branch's copy when that lands)
- `.github/workflows/nightly_android_e2e.yml` — nightly + `workflow_dispatch` job: KVM emulator (API 35, x86_64), APK build, Maestro run, server-side traffic assertion, debug artifacts on failure
- `docs/qa-automation-plan.md` — spike marked done, Phase 3 status updated

## Honest caveat

The spike ran on a local arm64 emulator. The CI x86_64/KVM emulator is expected to behave identically but is **unproven** — dispatch the nightly workflow on this branch as the first review step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)