### PR TITLE
feat(manager): gcp flows in the qa automation suite

### DIFF
--- a/docs/manager-qa-automation-plan.md
+++ b/docs/manager-qa-automation-plan.md
@@ -83,14 +83,16 @@ DigitalOcean code over the intercepted REST API. Covers
 `ServerCreate.DigitalOcean`, `ServerConnect.DigitalOcean`,
 `ServerDestroy.DigitalOcean` (UI halves; the full-stack halves are Layer 4).
 
-GCP is the remaining provider. It needs (a) a `runGcpOauth` stub in
-`browser_main.ts` (the browser build currently has none, so the GCP intro
-card is unusable outside Electron), and (b) a substantially larger
-intercepted surface than DigitalOcean: the OAuth token exchange, Compute
-(instances, static IPs, guest attributes, firewalls, zones, operation
-polling), Resource Manager (project create/list + operations), Service Usage
-(list/batchEnable + operations) and Cloud Billing. Deferred to its own
-phase.
+The GCP flows run the same way against a larger intercepted surface
+(`server_manager/e2e/tests/fake_gcp.ts`): the OAuth token exchange, OpenID
+userinfo, Compute (instances, static IPs, guest attributes, firewalls,
+zones, operation polling), Resource Manager, Service Usage and Cloud
+Billing. `browser_main.ts` gained a `runGcpOauth` prompt stub (mirroring the
+DigitalOcean one), which also makes the GCP card usable in browser dev mode.
+Covers `ServerCreate.GCP` (both the existing-project fast path and the
+first-run billing-verification + project-creation flow),
+`ServerConnect.GCP`, `ServerDestroy.GCP` (UI halves; full-stack is
+Layer 4).
 
 ### Layer 2 — Real-Shadowbox integration (hermetic server, nightly)
 
@@ -206,8 +208,9 @@ explicitly. Shared with the client plan's Phase 5 tooling.
   - [x] DigitalOcean flows against an intercepted DO API
         (`fake_digitalocean.ts`; ServerCreate/ServerConnect/ServerDestroy
         .DigitalOcean)
-  - [ ] GCP flows against an intercepted GCP API (needs a browser
-        `runGcpOauth` stub first; see the Layer 1 section)
+  - [x] GCP flows against an intercepted GCP API (`fake_gcp.ts` + browser
+        `runGcpOauth` stub; ServerCreate/ServerConnect/ServerDestroy.GCP,
+        including the first-run billing + project-creation flow)
 - [ ] **Phase 2 — hermetic real server**
   - [x] Real-Shadowbox journey + nightly job
         (`server_manager/e2e/test_real`, `real_shadowbox_e2e` in

--- a/server_manager/e2e/README.md
+++ b/server_manager/e2e/README.md
@@ -55,9 +55,8 @@ Both run nightly in CI (`.github/workflows/nightly_manager_e2e.yml`).
   For the Electron suite the same fake serves over a real local HTTPS socket
   instead (CDP-fulfilled responses reach the `outline://` renderer with
   status 0).
-- The DigitalOcean flows run against an intercepted DO REST API
-  (tests/fake_digitalocean.ts); the token prompt of the browser build's
-  OAuth stub is answered via Playwright's dialog handler. GCP is not covered
-  yet; see the phasing section of the plan.
+- The cloud-provider flows run against intercepted provider APIs
+  (tests/fake_digitalocean.ts, tests/fake_gcp.ts); the token prompts of the
+  browser build's OAuth stubs are answered via Playwright's dialog handler.
 - Prefer `data-testid` selectors (or existing stable `id`s); add new ones to
   components rather than relying on classes or localized text.

--- a/server_manager/e2e/tests/fake_gcp.ts
+++ b/server_manager/e2e/tests/fake_gcp.ts
@@ -1,0 +1,394 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type {Page, Route} from '@playwright/test';
+
+import type {FakeShadowbox} from './fake_shadowbox';
+
+/**
+ * A fake of the GCP API surface the manager uses, mounted into the page with
+ * `page.route()`.
+ *
+ * The manager drives GCP entirely from the renderer over `fetch` (see
+ * server_manager/cloud/gcp_api.ts), across six hosts: the OAuth token
+ * endpoint, OpenID userinfo, Compute Engine, Resource Manager, Service Usage
+ * and Cloud Billing. A created instance completes its "install" through the
+ * guest-attributes poll (`outline/` namespace): one poll of
+ * `install-started`, then `apiUrl`/`certSha256` pointing at the
+ * FakeShadowbox passed to the constructor (see
+ * server_manager/www/gcp_server.ts; polls are 5s apart, so creation takes
+ * one cycle, keeping the progress view visible long enough to avoid the
+ * stuck-progress race an instant install would cause).
+ */
+
+const COMPUTE_BASE = 'https://compute.googleapis.com/compute/v1';
+
+interface FakeInstance {
+  id: string;
+  name: string;
+  description: string;
+  zoneId: string;
+  natIP: string;
+  /** Guest-attribute polls left before the install attributes appear. */
+  pollsUntilInstalled: number;
+}
+
+export class FakeGcp {
+  readonly instances: FakeInstance[] = [];
+  /** Project IDs known to the account, mapped to "healthy" state. */
+  readonly projects = new Map<
+    string,
+    {billingEnabled: boolean; computeEnabled: boolean}
+  >();
+  private billingAccounts: {displayName: string}[] = [];
+  private hasFirewall = false;
+  private readonly staticIps = new Set<string>();
+  private nextId = 5000;
+
+  constructor(private readonly shadowbox: FakeShadowbox) {}
+
+  /** Starts intercepting the GCP APIs on `page`. */
+  async install(page: Page): Promise<void> {
+    const hosts = [
+      'https://oauth2.googleapis.com/**',
+      'https://openidconnect.googleapis.com/**',
+      'https://compute.googleapis.com/**',
+      'https://cloudresourcemanager.googleapis.com/**',
+      'https://serviceusage.googleapis.com/**',
+      'https://cloudbilling.googleapis.com/**',
+    ];
+    for (const host of hosts) {
+      await page.route(host, route => this.handle(route));
+    }
+  }
+
+  /** Simulates an account with an open billing account. */
+  seedBillingAccount(displayName = 'E2E Billing Account'): void {
+    this.billingAccounts.push({displayName});
+  }
+
+  /** Simulates a fully set-up "Outline servers" project. */
+  seedHealthyProject(projectId = 'outline-e2e-project'): void {
+    this.projects.set(projectId, {billingEnabled: true, computeEnabled: true});
+  }
+
+  /** Simulates an existing, fully installed server in the project. */
+  seedInstalledInstance(zoneId = 'us-central1-a'): void {
+    const instance = this.makeInstance('Existing GCP Server', zoneId);
+    instance.pollsUntilInstalled = 0;
+    this.instances.push(instance);
+  }
+
+  private makeInstance(description: string, zoneId: string): FakeInstance {
+    return {
+      id: String(this.nextId++),
+      name: `outline-e2e-${this.nextId}`,
+      description,
+      zoneId,
+      natIP: '203.0.113.55',
+      pollsUntilInstalled: 1,
+    };
+  }
+
+  private instanceJson(projectId: string, instance: FakeInstance) {
+    return {
+      id: instance.id,
+      name: instance.name,
+      description: instance.description,
+      zone: `${COMPUTE_BASE}/projects/${projectId}/zones/${instance.zoneId}`,
+      labels: {outline: 'true'},
+      networkInterfaces: [{accessConfigs: [{natIP: instance.natIP}]}],
+    };
+  }
+
+  private computeOperation(targetId = '') {
+    return {
+      id: String(this.nextId++),
+      name: `operation-${this.nextId}`,
+      targetId,
+      status: 'DONE',
+    };
+  }
+
+  private handle(route: Route): Promise<void> {
+    const request = route.request();
+    const url = new URL(request.url());
+    const method = request.method();
+    const json = (body: unknown, status = 200) =>
+      route.fulfill({status, json: body});
+
+    // OAuth: refresh token -> access token.
+    if (url.hostname === 'oauth2.googleapis.com') {
+      return json({access_token: 'fake-gcp-access-token', expires_in: 3600});
+    }
+    if (url.hostname === 'openidconnect.googleapis.com') {
+      return json({email: 'e2e-gcp@example.com'});
+    }
+    if (url.hostname === 'cloudbilling.googleapis.com') {
+      return this.handleBilling(url, method, json);
+    }
+    if (url.hostname === 'cloudresourcemanager.googleapis.com') {
+      return this.handleResourceManager(
+        url,
+        method,
+        request.postDataJSON.bind(request),
+        json
+      );
+    }
+    if (url.hostname === 'serviceusage.googleapis.com') {
+      return this.handleServiceUsage(url, method, json);
+    }
+    if (url.hostname === 'compute.googleapis.com') {
+      return this.handleCompute(
+        url,
+        method,
+        request.postDataJSON.bind(request),
+        json
+      );
+    }
+    console.warn(`FakeGcp: unhandled host ${url.hostname}`);
+    return json({error: {message: `unhandled: ${url.hostname}`}}, 404);
+  }
+
+  private handleBilling(
+    url: URL,
+    method: string,
+    json: (body: unknown, status?: number) => Promise<void>
+  ): Promise<void> {
+    if (url.pathname === '/v1/billingAccounts') {
+      return json({
+        billingAccounts: this.billingAccounts.map((account, index) => ({
+          name: `billingAccounts/BILLING-${index}`,
+          open: true,
+          displayName: account.displayName,
+        })),
+      });
+    }
+    const billingInfoMatch = url.pathname.match(
+      /^\/v1\/projects\/([^/]+)\/billingInfo$/
+    );
+    if (billingInfoMatch) {
+      const projectId = billingInfoMatch[1];
+      const project = this.projects.get(projectId);
+      if (method === 'PUT') {
+        if (project) {
+          project.billingEnabled = true;
+        }
+        return json({projectId, billingEnabled: true});
+      }
+      return json({
+        projectId,
+        billingEnabled: project?.billingEnabled ?? false,
+      });
+    }
+    console.warn(`FakeGcp: unhandled billing ${method} ${url.pathname}`);
+    return json({error: {message: 'unhandled'}}, 404);
+  }
+
+  private handleResourceManager(
+    url: URL,
+    method: string,
+    postDataJSON: () => {projectId?: string},
+    json: (body: unknown, status?: number) => Promise<void>
+  ): Promise<void> {
+    if (url.pathname === '/v1/projects' && method === 'GET') {
+      return json({
+        projects: [...this.projects.keys()].map(projectId => ({
+          projectId,
+          name: 'Outline servers',
+          lifecycleState: 'ACTIVE',
+        })),
+      });
+    }
+    if (url.pathname === '/v1/projects' && method === 'POST') {
+      const projectId = postDataJSON().projectId;
+      this.projects.set(projectId, {
+        billingEnabled: false,
+        computeEnabled: false,
+      });
+      return json({name: 'operations/create-project', done: false});
+    }
+    if (url.pathname === '/v1/operations/create-project') {
+      return json({name: 'operations/create-project', done: true});
+    }
+    console.warn(`FakeGcp: unhandled rm ${method} ${url.pathname}`);
+    return json({error: {message: 'unhandled'}}, 404);
+  }
+
+  private handleServiceUsage(
+    url: URL,
+    method: string,
+    json: (body: unknown, status?: number) => Promise<void>
+  ): Promise<void> {
+    const servicesMatch = url.pathname.match(
+      /^\/v1\/projects\/([^/]+)\/services(:batchEnable)?$/
+    );
+    if (servicesMatch && method === 'POST') {
+      const project = this.projects.get(servicesMatch[1]);
+      if (project) {
+        project.computeEnabled = true;
+      }
+      return json({name: 'operations/enable-services', done: false});
+    }
+    if (servicesMatch && method === 'GET') {
+      const project = this.projects.get(servicesMatch[1]);
+      return json({
+        services: project?.computeEnabled
+          ? [
+              {
+                name: `projects/${servicesMatch[1]}/services/compute.googleapis.com`,
+                config: {name: 'compute.googleapis.com'},
+                state: 'ENABLED',
+              },
+            ]
+          : [],
+      });
+    }
+    if (url.pathname === '/v1/operations/enable-services') {
+      return json({name: 'operations/enable-services', done: true});
+    }
+    console.warn(`FakeGcp: unhandled su ${method} ${url.pathname}`);
+    return json({error: {message: 'unhandled'}}, 404);
+  }
+
+  private handleCompute(
+    url: URL,
+    method: string,
+    postDataJSON: () => {name?: string; description?: string},
+    json: (body: unknown, status?: number) => Promise<void>
+  ): Promise<void> {
+    const path = url.pathname.replace('/compute/v1/', '');
+    const projectMatch = path.match(/^projects\/([^/]+)\/(.*)$/);
+    if (!projectMatch) {
+      return json({error: {message: 'bad path'}}, 404);
+    }
+    const [, projectId, rest] = projectMatch;
+
+    if (rest === 'zones' && method === 'GET') {
+      return json({
+        items: [
+          {name: 'us-central1-a', status: 'UP'},
+          {name: 'europe-west1-b', status: 'UP'},
+        ],
+      });
+    }
+    if (rest === 'aggregated/instances' && method === 'GET') {
+      const items: {[zone: string]: {instances: unknown[]}} = {};
+      for (const instance of this.instances) {
+        const zoneKey = `zones/${instance.zoneId}`;
+        items[zoneKey] ??= {instances: []};
+        items[zoneKey].instances.push(this.instanceJson(projectId, instance));
+      }
+      return json({items});
+    }
+    if (rest === 'global/firewalls' && method === 'GET') {
+      return json({
+        items: this.hasFirewall ? [{name: 'outline'}] : [],
+      });
+    }
+    if (rest === 'global/firewalls' && method === 'POST') {
+      this.hasFirewall = true;
+      return json(this.computeOperation());
+    }
+    if (/^global\/operations\/[^/]+\/wait$/.test(rest)) {
+      return json(this.computeOperation());
+    }
+
+    const zoneMatch = rest.match(/^zones\/([^/]+)\/(.*)$/);
+    if (zoneMatch) {
+      const [, zoneId, zoneRest] = zoneMatch;
+      if (zoneRest === 'instances' && method === 'POST') {
+        const body = postDataJSON();
+        const instance = this.makeInstance(body.description ?? '', zoneId);
+        instance.name = body.name ?? instance.name;
+        this.instances.push(instance);
+        return json(this.computeOperation(instance.id), 201);
+      }
+      if (/^operations\/[^/]+\/wait$/.test(zoneRest)) {
+        return json(this.computeOperation());
+      }
+      const instanceMatch = zoneRest.match(
+        /^instances\/([^/]+)(\/getGuestAttributes)?$/
+      );
+      if (instanceMatch) {
+        const instance = this.instances.find(i => i.id === instanceMatch[1]);
+        if (!instance) {
+          return json({error: {message: 'not found'}}, 404);
+        }
+        if (instanceMatch[2]) {
+          return json(this.guestAttributes(instance));
+        }
+        if (method === 'DELETE') {
+          this.instances.splice(this.instances.indexOf(instance), 1);
+          return json(this.computeOperation(instance.id));
+        }
+        return json(this.instanceJson(projectId, instance));
+      }
+    }
+
+    const regionMatch = rest.match(/^regions\/([^/]+)\/(.*)$/);
+    if (regionMatch) {
+      const [, , regionRest] = regionMatch;
+      if (regionRest === 'addresses' && method === 'POST') {
+        this.staticIps.add(postDataJSON().name);
+        return json(this.computeOperation());
+      }
+      if (/^operations\/[^/]+\/wait$/.test(regionRest)) {
+        return json(this.computeOperation());
+      }
+      const addressMatch = regionRest.match(/^addresses\/([^/]+)$/);
+      if (addressMatch && method === 'DELETE') {
+        this.staticIps.delete(addressMatch[1]);
+        return json(this.computeOperation());
+      }
+      if (addressMatch) {
+        return this.staticIps.has(addressMatch[1])
+          ? json({name: addressMatch[1]})
+          : json({error: {message: 'not found'}}, 404);
+      }
+    }
+
+    console.warn(`FakeGcp: unhandled compute ${method} ${path}`);
+    return json({error: {message: `unhandled: ${method} ${path}`}}, 404);
+  }
+
+  private guestAttributes(instance: FakeInstance) {
+    if (instance.pollsUntilInstalled > 0) {
+      instance.pollsUntilInstalled--;
+      return {
+        queryPath: 'outline/',
+        queryValue: {
+          items: [
+            {namespace: 'outline', key: 'install-started', value: 'true'},
+          ],
+        },
+      };
+    }
+    return {
+      queryPath: 'outline/',
+      queryValue: {
+        items: [
+          {namespace: 'outline', key: 'apiUrl', value: this.shadowbox.apiUrl},
+          {
+            namespace: 'outline',
+            key: 'certSha256',
+            // GcpServer passes atob(certSha256) as the pin; the browser
+            // build's fetchWithPin ignores it.
+            value: btoa('fake-certificate-fingerprint-32b!'),
+          },
+        ],
+      },
+    };
+  }
+}

--- a/server_manager/e2e/tests/gcp.spec.ts
+++ b/server_manager/e2e/tests/gcp.spec.ts
@@ -1,0 +1,161 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// GCP checklist items (ServerCreate/ServerConnect/ServerDestroy.GCP),
+// against a route-intercepted GCP API surface (see fake_gcp.ts). The
+// browser build's OAuth stub asks for the refresh token via window.prompt,
+// which the tests answer through Playwright's dialog handler — everything
+// after that runs the app's real GCP code over the intercepted APIs.
+// Test titles reference the QA checklist IDs in
+// docs/manager-qa-automation-plan.md.
+
+import {test, expect, type Page} from '@playwright/test';
+
+import {FakeGcp} from './fake_gcp';
+import {FakeShadowbox} from './fake_shadowbox';
+import {
+  accessKeyRows,
+  appRoot,
+  englishMessage,
+  introPage,
+  loadApp,
+  serverView,
+  toast,
+} from './helpers';
+
+/** Clicks the GCP intro card and answers the refresh-token prompt. */
+async function connectGcp(page: Page): Promise<void> {
+  page.once('dialog', dialog => void dialog.accept('fake-gcp-refresh-token'));
+  // Two #gcp cards exist (new flow + hidden legacy); target the visible one.
+  await introPage(page).locator('#gcp:not([hidden]) .card-footer').click();
+}
+
+test('ServerCreate.GCP: user can create a new server in an existing project', async ({
+  page,
+}) => {
+  const shadowbox = new FakeShadowbox();
+  const gcp = new FakeGcp(shadowbox);
+  gcp.seedBillingAccount();
+  gcp.seedHealthyProject();
+  await shadowbox.install(page);
+  await gcp.install(page);
+  await loadApp(page);
+
+  await connectGcp(page);
+
+  // The project is healthy, so the flow lands directly on the zone picker.
+  const createServerApp = appRoot(page).locator('#gcpCreateServer');
+  const regionPicker = createServerApp.locator('#regionPicker');
+  await expect(regionPicker.locator('label.city-button').first()).toBeVisible();
+  await regionPicker.locator('label.city-button').first().click();
+  await regionPicker.locator('#createServerButton').click();
+
+  // The guest-attribute install completes after one 5s poll cycle; the
+  // progress view is shown meanwhile.
+  await expect(serverView(page)).toContainText(
+    englishMessage('setup-do-title'),
+    {timeout: 15000}
+  );
+  await expect(accessKeyRows(page)).toHaveCount(1, {timeout: 20000});
+  expect(gcp.instances).toHaveLength(1);
+});
+
+test('ServerCreate.GCP (first run): billing verification and project creation lead to the zone picker', async ({
+  page,
+}) => {
+  const shadowbox = new FakeShadowbox();
+  const gcp = new FakeGcp(shadowbox);
+  await shadowbox.install(page);
+  await gcp.install(page);
+  await loadApp(page);
+
+  // With no billing account, the flow parks on the billing setup page and
+  // polls every 5s.
+  await connectGcp(page);
+  const createServerApp = appRoot(page).locator('#gcpCreateServer');
+  await expect(createServerApp.locator('#billingAccountSetup')).toBeVisible();
+
+  // The user sets up billing on the GCP console; the poll picks it up and
+  // advances to project setup.
+  gcp.seedBillingAccount();
+  await expect(createServerApp.locator('#projectSetup')).toBeVisible({
+    timeout: 15000,
+  });
+
+  // Create the "Outline servers" project (billing link + API enablement).
+  await createServerApp.locator('#createServerButton').click();
+  await expect(
+    createServerApp.locator('#regionPicker label.city-button').first()
+  ).toBeVisible({timeout: 20000});
+  expect(gcp.projects.size).toBe(1);
+});
+
+test('ServerConnect.GCP: existing GCP servers are found after sign-in and restarts', async ({
+  page,
+}) => {
+  const shadowbox = new FakeShadowbox({name: 'Existing GCP Server'});
+  const gcp = new FakeGcp(shadowbox);
+  gcp.seedBillingAccount();
+  gcp.seedHealthyProject();
+  gcp.seedInstalledInstance();
+  await shadowbox.install(page);
+  await gcp.install(page);
+  await loadApp(page);
+
+  // Signing in to an account whose project already has an Outline instance
+  // must land directly on that server.
+  await connectGcp(page);
+  await expect(serverView(page)).toContainText('Existing GCP Server', {
+    timeout: 15000,
+  });
+
+  // The account connection persists across restarts.
+  await page.reload();
+  await serverView(page).waitFor({timeout: 15000});
+  await expect(serverView(page)).toContainText('Existing GCP Server');
+});
+
+test('ServerDestroy.GCP: user can destroy an existing GCP server', async ({
+  page,
+}) => {
+  const shadowbox = new FakeShadowbox();
+  const gcp = new FakeGcp(shadowbox);
+  gcp.seedBillingAccount();
+  gcp.seedHealthyProject();
+  gcp.seedInstalledInstance();
+  await shadowbox.install(page);
+  await gcp.install(page);
+  await loadApp(page);
+  await connectGcp(page);
+  await serverView(page).waitFor({timeout: 15000});
+
+  await serverView(page).locator('paper-icon-button[icon="more-vert"]').click();
+  await serverView(page)
+    .locator('paper-item', {hasText: englishMessage('server-destroy')})
+    .click();
+  await appRoot(page)
+    .locator('outline-modal-dialog paper-button', {
+      hasText: englishMessage('destroy'),
+    })
+    .click();
+
+  await expect(toast(page)).toContainText(
+    englishMessage('notification-server-destroyed')
+  );
+  expect(gcp.instances).toHaveLength(0);
+
+  // The instance is gone from the project: a restart must not resurrect it.
+  await page.reload();
+  await expect(introPage(page).locator('#gcp:not([hidden])')).toBeVisible();
+});

--- a/server_manager/www/browser_main.ts
+++ b/server_manager/www/browser_main.ts
@@ -73,6 +73,36 @@
   };
 };
 
+// Mirrors the DigitalOcean stub above: the browser build cannot run the
+// full OAuth dance the Electron build does, so ask for a refresh token
+// directly. Also used by the E2E suite (server_manager/e2e), which answers
+// the prompt through Playwright's dialog handler.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(window as any).runGcpOauth = () => {
+  let isCancelled = false;
+  const rejectWrapper = {reject: (_error: Error) => {}};
+  const result = new Promise((resolve, reject) => {
+    rejectWrapper.reject = reject;
+    const refreshToken = window.prompt('Please enter your GCP refresh token');
+    if (refreshToken) {
+      resolve(refreshToken);
+    } else {
+      reject(new Error('No refresh token entered'));
+    }
+  });
+  return {
+    result,
+    isCancelled() {
+      return isCancelled;
+    },
+    cancel() {
+      console.log('Session cancelled');
+      isCancelled = true;
+      rejectWrapper.reject(new Error('Authentication cancelled'));
+    },
+  };
+};
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (window as any).bringToFront = () => {
   console.info('Requested bringToFront');


### PR DESCRIPTION
## Summary

Stacked on #2805 (which stacks on #2802). Completes the cloud-provider half of Layer 1 in `docs/manager-qa-automation-plan.md` — the last P0 checklist gap outside the release gate.

- **Fake GCP surface** (`tests/fake_gcp.ts`): route-intercepts the six Google hosts the manager talks to — OAuth token exchange, OpenID userinfo, Compute Engine (instances, static-IP promotion, guest attributes, firewalls, zones, zone/region/global operation waits), Resource Manager (project creation with operation polling), Service Usage (batchEnable + polling), and Cloud Billing. A created instance completes its "install" via the guest-attributes poll — one cycle of `install-started`, then `apiUrl`/`certSha256` pointing at the fake Shadowbox — so the progress view is exercised and the instant-install race is avoided (same lesson as the DigitalOcean fake).
- **Tests** (`tests/gcp.spec.ts`, 4 tests):
  - `ServerCreate.GCP` — existing healthy project → zone picker → create → server view with the first access key.
  - `ServerCreate.GCP (first run)` — no billing account: the flow parks on billing verification, picks up a newly added billing account via its 5s poll, creates the "Outline servers" project (billing link + API enablement + operation polling), and lands on the zone picker.
  - `ServerConnect.GCP` — sign-in discovers an existing instance via `aggregatedList`; persists across reload.
  - `ServerDestroy.GCP` — destroy confirms, deletes the static IP and instance, returns to intro, stays gone after reload.
- **Groundwork**: `browser_main.ts` gains a `runGcpOauth` prompt stub mirroring the DigitalOcean one. Besides enabling the tests, this fixes the GCP intro card in browser dev mode, which previously threw (no stub existed).

## Test plan

- `npm run action server_manager/e2e/test` — 18/18 (14 from #2805 + 4 GCP)
- `npm run lint:gts` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)