### PR TITLE
chore(client/android): upgrade Cordova and CI Android build to JDK 21

### DIFF
--- a/.github/workflows/build_and_test_debug_client.yml
+++ b/.github/workflows/build_and_test_debug_client.yml
@@ -261,7 +261,7 @@ jobs:
           cache-dependency-path: ./package-lock.json
 
       - name: Setup Java
-        run: echo "JAVA_HOME=$JAVA_HOME_17_X64" >> $GITHUB_ENV
+        run: echo "JAVA_HOME=$JAVA_HOME_21_X64" >> $GITHUB_ENV
 
       - name: Install NPM Dependencies
         run: npm ci

--- a/client/build/configure_android.sh
+++ b/client/build/configure_android.sh
@@ -15,19 +15,19 @@
 
 main() {
     declare java_home android_home android_ndk
-    # Note: JAVA_HOME_17_{X64,arm64} are variables provided by the Github runners, so we add them here for convenience.
+    # Note: JAVA_HOME_21_{X64,arm64} are variables provided by the Github runners, so we add them here for convenience.
     case "$(uname)" in
         'Linux')
-        java_home="${JAVA_HOME_17_X64:-${JAVA_HOME:-/usr/lib/jvm/java-17-openjdk-amd64}}"
+        java_home="${JAVA_HOME_21_X64:-${JAVA_HOME:-/usr/lib/jvm/java-21-openjdk-amd64}}"
         android_home="${ANDROID_HOME:-${HOME}/Android/Sdk}"
         ;;
         'Darwin')
-        java_home="${JAVA_HOME_17_arm64:-${JAVA_HOME:-$(/usr/libexec/java_home -v 17.0)}}"
+        java_home="${JAVA_HOME_21_arm64:-${JAVA_HOME:-$(/usr/libexec/java_home -v 21)}}"
         android_home="${ANDROID_HOME:-$HOME/Library/Android/sdk}"
         ;;
         'MINGW64_NT'* | 'CYGWIN'* | 'Windows_NT')
         # Assuming a bash-like shell (e.g., Git Bash) is used on Windows
-        java_home="${JAVA_HOME_17_X64:-${JAVA_HOME:-C:/Program Files/Java/jdk-17}}"
+        java_home="${JAVA_HOME_21_X64:-${JAVA_HOME:-C:/Program Files/Java/jdk-21}}"
         android_home="${ANDROID_HOME:-$LOCALAPPDATA/Android/Sdk}"
         ;;
     esac

--- a/client/config.xml
+++ b/client/config.xml
@@ -25,6 +25,11 @@
     <allow-intent href="https://*/*" />
     <preference name="android-minSdkVersion" value="29" />
     <preference name="android-targetSdkVersion" value="35" />
+    <!-- Match the Android Gradle Plugin version used by the Capacitor client
+         (client/capacitor/android). Keep in sync with the AGP version declared
+         in client/src/cordova/android/OutlineAndroidLib/build.gradle, which is
+         part of the same Gradle composite build. -->
+    <preference name="AndroidGradlePluginVersion" value="8.9.1" />
     <preference name="AndroidLaunchMode" value="singleInstance" />
     <preference name="ShowSplashScreenSpinner" value="false" />
     <preference name="Orientation" value="portrait" />

--- a/client/src/cordova/android/OutlineAndroidLib/build.gradle
+++ b/client/src/cordova/android/OutlineAndroidLib/build.gradle
@@ -14,6 +14,8 @@
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    // This version number must be kept in sync with AGP_VERSION in cordova-android.
-    id 'com.android.library' version '8.7.3' apply false
+    // This version number must be kept in sync with AGP_VERSION in cordova-android
+    // (overridden to match the Capacitor client via the AndroidGradlePluginVersion
+    // preference in client/config.xml).
+    id 'com.android.library' version '8.9.1' apply false
 }

--- a/client/src/cordova/android/OutlineAndroidLib/outline/build.gradle
+++ b/client/src/cordova/android/OutlineAndroidLib/outline/build.gradle
@@ -49,8 +49,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
+        sourceCompatibility JavaVersion.VERSION_21
+        targetCompatibility JavaVersion.VERSION_21
     }
 }
 

--- a/client/src/cordova/android/README.md
+++ b/client/src/cordova/android/README.md
@@ -8,20 +8,20 @@ The main entrypoint to Android's Java code is `client/src/cordova/plugin/android
 
 Install these pre-requisites:
 
-- [Java Development Kit (JDK) 17+](https://jdk.java.net/archive/). On macOS:
+- [Java Development Kit (JDK) 21+](https://jdk.java.net/archive/). On macOS:
 
   ```shell
-  brew install openjdk@17
+  brew install openjdk@21
 
   # Make it visible to `java_home`
-  sudo ln -sfn "$(realpath "$(brew --prefix)")/opt/openjdk@17/libexec/openjdk.jdk" /Library/Java/JavaVirtualMachines/openjdk-17.jdk
+  sudo ln -sfn "$(realpath "$(brew --prefix)")/opt/openjdk@21/libexec/openjdk.jdk" /Library/Java/JavaVirtualMachines/openjdk-21.jdk
 
-  export JAVA_HOME=$(/usr/libexec/java_home -v 17.0)
+  export JAVA_HOME=$(/usr/libexec/java_home -v 21)
   ```
 
 - [Gradle 8.7+](https://gradle.org/install/). On macOS: `brew install gradle`.
 
-Then we need to install and configure the Android components. You can follow the [Cordova Android Platform Guide](https://cordova.apache.org/docs/en/latest/guide/platforms/android/index.html), which uses Android Studio to configure the environment. You need an Android Studio compatible with the Android Gradle Plugin 8.3.0 (see [build.gradle](client/src/cordova/android/OutlineAndroidLib/build.gradle)) we use ([compatibility table](https://developer.android.com/studio/releases#android_gradle_plugin_and_android_studio_compatibility)).
+Then we need to install and configure the Android components. You can follow the [Cordova Android Platform Guide](https://cordova.apache.org/docs/en/latest/guide/platforms/android/index.html), which uses Android Studio to configure the environment. You need an Android Studio compatible with the Android Gradle Plugin 8.9.1 (see [build.gradle](client/src/cordova/android/OutlineAndroidLib/build.gradle)) we use ([compatibility table](https://developer.android.com/studio/releases#android_gradle_plugin_and_android_studio_compatibility)).
 
 Alternatively, you can do it on the command-line:
 
@@ -72,11 +72,11 @@ npx cordova requirements android
 |---|---|---|---|
 | Android API Level | 35+ | [Play Store](https://developer.android.com/google/play/requirements/target-sdk) | [config.xml](../../../config.xml), [build.gradle](./OutlineAndroidLib/outline/build.gradle) |
 | cordova-android | 14 | Android API Level | [package.json](../../../package.json) |
-| JDK | 17 | [cordova-android](https://cordova.apache.org/docs/en/latest/guide/platforms/android/index.html#android-api-level-support) | install instruction |
+| JDK | 21 | [cordova-android](https://cordova.apache.org/docs/en/latest/guide/platforms/android/index.html#android-api-level-support) | install instruction |
 | Gradle | 8.13+ | [cordova-android](https://cordova.apache.org/docs/en/latest/guide/platforms/android/index.html#android-api-level-support) | [gradle-wrapper.properties](./OutlineAndroidLib/gradle/wrapper/gradle-wrapper.properties) |
-| Android Gradle Plugin (AGP) | 8.7.3 | [cordova-android](https://cordova.apache.org/docs/en/latest/guide/platforms/android/index.html#android-api-level-support) | [build.gradle](../android/OutlineAndroidLib/build.gradle) |
+| Android Gradle Plugin (AGP) | 8.9.1 | [Capacitor client](../../../capacitor/android/build.gradle) | [config.xml](../../../config.xml), [build.gradle](../android/OutlineAndroidLib/build.gradle) |
 | Android Build Tools | 35.0.0+ | [cordova-android](https://cordova.apache.org/docs/en/latest/guide/platforms/android/index.html#android-api-level-support) | install instructions |
-| Android Studio | 2024.2.2 (Ladybug Feature Drop) | [AGP](https://developer.android.com/studio/releases#android_gradle_plugin_and_android_studio_compatibility) | |
+| Android Studio | 2024.3.1 (Meerkat) | [AGP](https://developer.android.com/studio/releases#android_gradle_plugin_and_android_studio_compatibility) | |
 
 ## Build the app
 


### PR DESCRIPTION
## Context

The new Capacitor Android app ([#2783](https://github.com/OutlineFoundation/outline-apps/pull/2783)) uses a newer Android toolchain than the existing Cordova build. This PR narrows that gap on `master` (independent of #2783) so both apps can share one toolchain, and lets CI tell us whether the Cordova build survives the bumps.

## Toolchain comparison

| | Capacitor (#2783) | Cordova (before) | This PR |
|---|---|---|---|
| JDK (build + CI) | 21 | 17 (CI) / 11 (lib) | **21** |
| AGP | 8.9.1 | 8.7.3 | **8.9.1** |
| Gradle | 8.11.1 | 8.13 | 8.13 (unchanged — matching would be a downgrade) |
| Kotlin | 2.0.21 | n/a | n/a (Cordova has no Kotlin sources) |

## Changes

**JDK 21**
- Cordova `OutlineAndroidLib` source/target compatibility 11 → 21
- CI `Setup Java` step `JAVA_HOME_17_X64` → `JAVA_HOME_21_X64`

**AGP 8.9.1** (Cordova app + `OutlineAndroidLib` are one Gradle composite build via `--include-build`, so AGP must match on both sides)
- `client/config.xml`: override cordova-android's `AGP_VERSION` 8.7.3 → 8.9.1 via the `AndroidGradlePluginVersion` preference
- `OutlineAndroidLib/build.gradle`: `com.android.library` 8.7.3 → 8.9.1

## Deliberately left alone
- **Gradle version** — Cordova (8.13) is already newer than Capacitor (8.11.1).
- **Kotlin** — no `.kt` sources in the Cordova stack, so the version is inert.
- **SDK levels** (compileSdk/targetSdk/minSdk) — the Cordova app has its own values (`minSdk 29`, `targetSdk 35`); not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)