### PR TITLE
ci(client): build the Capacitor Android app on CI

### DIFF
--- a/.github/workflows/build_and_test_debug_client.yml
+++ b/.github/workflows/build_and_test_debug_client.yml
@@ -299,9 +299,4 @@ jobs:
           go-version-file: '${{ github.workspace }}/go.mod'
 
       - name: Build Android Capacitor Client
-        run: |
-          npm run action client/capacitor/web_build android
-          cd client/capacitor
-          npx cap sync android
-          cd android
-          ./gradlew assembleDebug
+        run: npm run action client/capacitor/build android

--- a/.github/workflows/build_and_test_debug_client.yml
+++ b/.github/workflows/build_and_test_debug_client.yml
@@ -268,3 +268,40 @@ jobs:
 
       - name: Build Android Client
         run: npm run action client/src/cordova/build android -- --verbose
+
+  capacitor_android_debug_build:
+    name: Android Capacitor Debug Build
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    needs: [web_test, backend_test]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: ./package-lock.json
+
+      - name: Setup Java
+        # Capacitor 8's Android project targets Java 21 (see
+        # client/capacitor/android/app/build.gradle), so build with JDK 21.
+        run: echo "JAVA_HOME=$JAVA_HOME_21_X64" >> $GITHUB_ENV
+
+      - name: Install NPM Dependencies
+        run: npm ci
+
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: '${{ github.workspace }}/go.mod'
+
+      - name: Build Android Capacitor Client
+        run: |
+          npm run action client/capacitor/web_build android
+          cd client/capacitor
+          npx cap sync android
+          cd android
+          ./gradlew assembleDebug

--- a/client/capacitor/README.md
+++ b/client/capacitor/README.md
@@ -85,7 +85,7 @@ Use this flow when you need the real Outline Android plugin (VPN, native method 
 ### Requirements (Android)
 
 - [Android Studio](https://developer.android.com/studio) with a recent Android SDK (match the versions in `client/capacitor/android/variables.gradle` and root Gradle files).
-- **JDK 21** — the Android Gradle build compiles against Java 21 (see `client/capacitor/android/app/build.gradle`).
+- **JDK 21** — the Android Gradle build compiles against Java 21 (see `client/capacitor/android/app/build.gradle`). This differs from the Cordova Android client, which builds with JDK 17.
 - A **physical device** with USB debugging or an **AVD** emulator.
 - **Go** on your `PATH` (`npm run capacitor:sync:before` runs `go tool task` for tun2socks and Android configure; see `package.json` in this directory).
 

--- a/client/capacitor/README.md
+++ b/client/capacitor/README.md
@@ -89,6 +89,16 @@ Use this flow when you need the real Outline Android plugin (VPN, native method 
 - A **physical device** with USB debugging or an **AVD** emulator.
 - **Go** on your `PATH` (`npm run capacitor:sync:before` runs `go tool task` for tun2socks and Android configure; see `package.json` in this directory).
 
+### Build the debug APK (one command)
+
+From the **repository root**:
+
+```sh
+npm run action client/capacitor/build android
+```
+
+This runs the full build: the web bundle, `cap sync android` (tun2socks + native sync), and `gradlew assembleDebug`. It is what CI runs. To also install and launch the app on a device, use the steps below instead.
+
 ### Steps to build and start the app
 
 1. **Build the web bundle** (`www/`), from the **repository root**:

--- a/client/capacitor/README.md
+++ b/client/capacitor/README.md
@@ -1,8 +1,6 @@
-# Capacitor client (browser)
+# Capacitor client
 
-This directory is the Capacitor-based client shell. **This README documents the browser workflow only** (webpack bundle under `client/capacitor/www/`).
-
-Run all commands from the **repository root** using `npm run action`.
+This directory is the Capacitor-based client shell. These instructions cover both the **browser** dev workflow (webpack bundle under `client/capacitor/www/`) and the native **Android** build.
 
 ## Requirements (browser)
 
@@ -87,24 +85,31 @@ Use this flow when you need the real Outline Android plugin (VPN, native method 
 ### Requirements (Android)
 
 - [Android Studio](https://developer.android.com/studio) with a recent Android SDK (match the versions in `client/capacitor/android/variables.gradle` and root Gradle files).
+- **JDK 21** — the Android Gradle build compiles against Java 21 (see `client/capacitor/android/app/build.gradle`).
 - A **physical device** with USB debugging or an **AVD** emulator.
 - **Go** on your `PATH` (`npm run capacitor:sync:before` runs `go tool task` for tun2socks and Android configure; see `package.json` in this directory).
 
 ### Steps to build and start the app
 
-1. **Go to the Capacitor project directory:**
+1. **Build the web bundle** (`www/`), from the **repository root**:
+
+   ```sh
+   npm run action client/capacitor/web_build android
+   ```
+
+2. **Go to the Capacitor project directory:**
 
    ```sh
    cd client/capacitor
    ```
 
-2. **Sync the Android project** (runs `capacitor:sync:before`: Go tun2socks, Android configure; then copies web assets into the native app and refreshes plugins):
+3. **Sync the Android project** (runs `capacitor:sync:before`: Go tun2socks, Android configure; then copies the web assets built in step 1 into the native app and refreshes plugins):
 
    ```sh
    npx cap sync android
    ```
 
-3. **Install and launch** on the default device or running emulator:
+4. **Install and launch** on the default device or running emulator:
 
    ```sh
    npx cap run android

--- a/client/capacitor/build.action.mjs
+++ b/client/capacitor/build.action.mjs
@@ -37,6 +37,7 @@ export async function main(...parameters) {
     );
   }
 
+  // TODO: Support a release build once we're ready to migrate to Capacitor.
   if (buildMode !== 'debug') {
     throw new TypeError(
       `Capacitor ${platform} build supports only debug mode, got "${buildMode}".`

--- a/client/capacitor/build.action.mjs
+++ b/client/capacitor/build.action.mjs
@@ -58,6 +58,7 @@ export async function main(...parameters) {
 
   // `cap build` only produces signed release builds, so invoke Gradle
   // directly for the debug APK — the same target `cap run` uses.
+  // TODO: Migrate to a release Gradle target once we have a production build.
   const androidDir = path.resolve(capacitorDir, 'android');
   await spawnStream(
     path.join(androidDir, 'gradlew'),

--- a/client/capacitor/build.action.mjs
+++ b/client/capacitor/build.action.mjs
@@ -1,0 +1,72 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import path from 'path';
+import url from 'url';
+
+import {runAction} from '@outline/infrastructure/build/run_action.mjs';
+import {spawnStream} from '@outline/infrastructure/build/spawn_stream.mjs';
+
+import {getBuildParameters} from '../build/get_build_parameters.mjs';
+
+const capacitorDir = path.dirname(url.fileURLToPath(import.meta.url));
+
+/**
+ * @description Fully builds the Capacitor client: the web bundle, the
+ * tun2socks native library, and the native app binary.
+ *
+ * @param {string[]} parameters
+ */
+export async function main(...parameters) {
+  const {platform, buildMode, verbose} = getBuildParameters(parameters);
+
+  if (platform !== 'android') {
+    throw new TypeError(
+      `Capacitor build.action.mjs only supports the android platform, got "${platform}".`
+    );
+  }
+
+  if (buildMode !== 'debug') {
+    throw new TypeError(
+      `Capacitor ${platform} build supports only debug mode, got "${buildMode}".`
+    );
+  }
+
+  // Build the web bundle (client/capacitor/www/) that `cap sync` copies into
+  // the native project.
+  await runAction('client/capacitor/web_build', ...parameters);
+
+  // `cap sync` first runs the capacitor:sync:before hook (see package.json in
+  // this directory): the tun2socks gomobile AAR and client:android:configure.
+  // It then copies the web assets into the native project and refreshes the
+  // Capacitor plugins. The Capacitor CLI locates the project from the working
+  // directory.
+  process.chdir(capacitorDir);
+  await spawnStream('npx', 'cap', 'sync', platform);
+
+  // `cap build` only produces signed release builds, so invoke Gradle
+  // directly for the debug APK — the same target `cap run` uses.
+  const androidDir = path.resolve(capacitorDir, 'android');
+  await spawnStream(
+    path.join(androidDir, 'gradlew'),
+    '-p',
+    androidDir,
+    verbose ? '--info' : '--quiet',
+    'assembleDebug'
+  );
+}
+
+if (import.meta.url === url.pathToFileURL(process.argv[1]).href) {
+  await main(...process.argv.slice(2));
+}

--- a/client/capacitor/tsconfig.json
+++ b/client/capacitor/tsconfig.json
@@ -11,6 +11,7 @@
     "src",
     "plugins/capacitor-plugin-outline/src",
     "webpack.config.js",
+    "build.action.mjs",
     "web_build.action.mjs",
     "start.action.mjs"
   ],

--- a/client/capacitor/web_build.action.mjs
+++ b/client/capacitor/web_build.action.mjs
@@ -37,7 +37,7 @@ export async function main(...parameters) {
 
   if (!SUPPORTED_PLATFORMS.has(platform)) {
     throw new TypeError(
-      `Capacitor build.action.mjs supports platforms ${[...SUPPORTED_PLATFORMS].join(', ')}, got "${platform}".`
+      `Capacitor web_build.action.mjs supports platforms ${[...SUPPORTED_PLATFORMS].join(', ')}, got "${platform}".`
     );
   }
 


### PR DESCRIPTION
## What

Adds an **Android Capacitor Debug Build** job to `build_and_test_debug_client.yml` so the Capacitor Android app (added in #2783) is built on every PR, the same way the Cordova Android app already is. Also updates the Capacitor README's Android build instructions.

## CI job

Mirrors the existing `android_debug_build` (Cordova) job, with two Capacitor-8 differences:

- **JDK 21** (`JAVA_HOME_21_X64`) — Capacitor 8's Android project compiles against Java 21 (`client/capacitor/android/app/build.gradle`); JDK 17 fails with `invalid source release: 21`.
- **Go toolchain** — `cap sync` builds the tun2socks gomobile AAR via the `capacitor:sync:before` hook.

The build step is a single action, like the Cordova job:
```sh
npm run action client/capacitor/build android
```
The new `client/capacitor/build.action.mjs` runs web_build → `cap sync android` (tun2socks AAR + native sync) → `gradlew assembleDebug` (Gradle directly because `cap build` only produces signed release builds; debug is what `cap run` uses).

## README fixes (`client/capacitor/README.md`)

- Document the one-command build above, and the missing **web_build** step in the device flow (a fresh `cap sync` otherwise fails with `Could not find the web assets directory: ./www`).
- Document the **JDK 21** requirement (differs from the Cordova client's JDK 17).
- Drop the stale "browser workflow only" framing now that the file covers Android.

## Verified

`npm run action client/capacitor/build android` validated locally on a clean `npm ci` under JDK 21: `BUILD SUCCESSFUL`, `app-debug.apk` produced ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
