### PR TITLE
fix(client): replace contact us flow with a direct feedback form

### DIFF
--- a/client/web/ui_components/app-root.js
+++ b/client/web/ui_components/app-root.js
@@ -330,7 +330,6 @@ export class AppRoot extends mixinBehaviors(
             name="contact"
             id="contactView"
             localize="[[localize]]"
-            language-code="[[_computeSupportSiteLanguageCode(LANGUAGES_AVAILABLE, language)]]"
             error-reporter="[[errorReporter]]"
             on-success="showContactSuccessToast"
             on-error="showContactErrorToast"

--- a/client/web/views/contact_view/index.spec.ts
+++ b/client/web/views/contact_view/index.spec.ts
@@ -26,9 +26,7 @@ import {localize} from '../../testing/localize';
 
 describe('ContactView', () => {
   const ISSUE_TYPES = [
-    'no-server',
     'cannot-add-server',
-    'billing',
     'connection',
     'performance',
     'general',
@@ -55,191 +53,88 @@ describe('ContactView', () => {
     expect(el).toBeInstanceOf(ContactView);
   });
 
-  it('hides issue selector by default', async () => {
+  it('shows the issue selector', () => {
     const issueSelector = el.shadowRoot?.querySelector('mwc-select');
     expect(issueSelector).not.toBeNull();
-    expect(issueSelector!.hasAttribute('hidden')).toBeTrue();
   });
 
-  it('hides support form by default', async () => {
-    const supportForm = el.shadowRoot?.querySelector('support-form');
-    expect(supportForm).toBeNull();
+  it('shows the correct items in the selector', () => {
+    const issueSelector = el.shadowRoot!.querySelector('mwc-select')!;
+    const issueItemEls = issueSelector.querySelectorAll('mwc-list-item');
+    const issueTypes = Array.from(issueItemEls).map(
+      el => (el as {value: string}).value
+    );
+    expect(issueTypes).toEqual(ISSUE_TYPES);
   });
 
-  it('shows exit message if the user selects that they have an open ticket', async () => {
-    const radioButton = el.shadowRoot!.querySelectorAll(
-      'mwc-formfield mwc-radio'
-    )[0] as HTMLElement;
-    radioButton.click();
-    await nextFrame();
-
-    const exitCard = el.shadowRoot!.querySelector('.exit')!;
-    expect(exitCard.textContent).toContain('experiencing high support volume');
+  it('shows the support form', () => {
+    const supportForm = el.shadowRoot!.querySelector('support-form');
+    expect(supportForm).not.toBeNull();
   });
 
-  it('resets the view on `reset()`', async () => {
-    const radioButton = el.shadowRoot!.querySelectorAll(
-      'mwc-formfield mwc-radio'
-    )[0] as HTMLElement;
-    radioButton.click();
-    await nextFrame();
-
-    el.reset();
-    await nextFrame();
-
-    const exitCard = el.shadowRoot!.querySelector('.exit')!;
-    expect(exitCard).toBeNull();
-  });
-
-  describe('when the user selects that they have no open tickets', () => {
-    let issueSelector: Element;
+  describe('when the support form is submitted', () => {
+    let supportForm: SupportForm;
 
     beforeEach(async () => {
-      const radioButton = el.shadowRoot!.querySelectorAll(
-        'mwc-formfield mwc-radio'
-      )[1] as HTMLElement;
-      radioButton.click();
+      supportForm = el.shadowRoot!.querySelector('support-form')!;
+      supportForm.values.email = 'foo@bar.com';
+      supportForm.values.description = 'Test Description';
+      supportForm.valid = true;
+    });
+
+    it('reports the default "general" category when no issue is selected', async () => {
+      supportForm.dispatchEvent(new CustomEvent('submit'));
       await nextFrame();
 
-      issueSelector = el.shadowRoot!.querySelector('mwc-select')!;
-    });
-
-    it('shows the issue selector', () => {
-      expect(issueSelector.hasAttribute('hidden')).toBeFalse();
-    });
-
-    it('shows the correct items in the selector', () => {
-      const issueItemEls = issueSelector.querySelectorAll('mwc-list-item');
-      const issueTypes = Array.from(issueItemEls).map(
-        el => (el as {value: string}).value
+      expect(mockErrorReporter.sendFeedback).toHaveBeenCalledWith(
+        'Test Description',
+        'general',
+        'foo@bar.com',
+        {
+          formVersion: 2,
+        }
       );
-      expect(issueTypes).toEqual(ISSUE_TYPES);
     });
-  });
 
-  describe('when the user selects issue', () => {
-    let issueSelector: Element;
-
-    beforeEach(async () => {
-      issueSelector = el.shadowRoot!.querySelector('mwc-select')!;
-      const radioButton = el.shadowRoot!.querySelectorAll(
-        'mwc-formfield mwc-radio'
-      )[1] as HTMLElement;
-      radioButton.click();
+    it('reports the selected category', async () => {
+      const issueSelector = el.shadowRoot!.querySelector('mwc-select')!;
+      issueSelector.dispatchEvent(
+        new CustomEvent('selected', {
+          detail: {index: ISSUE_TYPES.indexOf('connection')},
+        })
+      );
       await nextFrame();
+
+      supportForm.dispatchEvent(new CustomEvent('submit'));
+      await nextFrame();
+
+      expect(mockErrorReporter.sendFeedback).toHaveBeenCalledWith(
+        'Test Description',
+        'connection',
+        'foo@bar.com',
+        {
+          formVersion: 2,
+        }
+      );
     });
 
-    const conditions = [
-      {
-        testcaseName: 'I need an access key',
-        value: 'no-server',
-        expectedMsg: 'does not distribute free or paid access keys',
-      },
-      {
-        testcaseName: 'I am having trouble adding a server using my access key',
-        value: 'cannot-add-server',
-        expectedMsg: 'assist with adding a server',
-      },
-      {
-        testcaseName: 'I need assistance with a billing or subscription issue',
-        value: 'billing',
-        expectedMsg: 'does not collect payment',
-      },
-      {
-        testcaseName: 'I am having trouble connecting to my Outline VPN server',
-        value: 'connection',
-        expectedMsg: 'assist with connecting to a server',
-      },
-    ];
+    it('emits success event on completion of support form', async () => {
+      const listener = oneEvent(el, 'success');
 
-    for (const {testcaseName, value, expectedMsg} of conditions) {
-      it(`'${testcaseName}' shows exit message`, async () => {
-        const selectedIndex = ISSUE_TYPES.indexOf(value);
-        issueSelector.dispatchEvent(
-          new CustomEvent('selected', {detail: {index: selectedIndex}})
-        );
-        await nextFrame();
+      supportForm.dispatchEvent(new CustomEvent('submit'));
 
-        const exitCard = el.shadowRoot!.querySelector('.exit')!;
-        expect(exitCard.textContent).toContain(expectedMsg);
-      });
-    }
+      const {detail} = await listener;
+      expect(detail).toBeNull();
+    });
 
-    describe('"General feedback & suggestions"', () => {
-      beforeEach(async () => {
-        issueSelector.dispatchEvent(
-          new CustomEvent('selected', {detail: {index: ISSUE_TYPES.length - 1}})
-        );
-        await nextFrame();
-      });
+    it('emits failure event when feedback reporting fails', async () => {
+      const listener = oneEvent(el, 'error');
+      mockErrorReporter.sendFeedback.and.throwError('fail');
 
-      it('shows support form', async () => {
-        const supportForm = el.shadowRoot!.querySelector('support-form')!;
-        expect(supportForm).not.toBeNull();
-      });
+      supportForm.dispatchEvent(new CustomEvent('submit'));
 
-      it('reports correct values to error reporter on completion of support form', async () => {
-        const supportForm: SupportForm =
-          el.shadowRoot!.querySelector('support-form')!;
-        supportForm.values.email = 'foo@bar.com';
-        supportForm.values.subject = 'Test Subject';
-        supportForm.values.accessKeySource = 'a friend';
-        supportForm.values.description = 'Test Description';
-        supportForm.values.outreachConsent = true;
-        supportForm.valid = true;
-        supportForm.dispatchEvent(new CustomEvent('submit'));
-        await nextFrame();
-
-        expect(mockErrorReporter.sendFeedback).toHaveBeenCalledWith(
-          'Test Description',
-          'general',
-          'foo@bar.com',
-          {
-            subject: 'Test Subject',
-            accessKeySource: 'a friend',
-            outreachConsent: true,
-            formVersion: 2,
-          }
-        );
-      });
-
-      it('emits success event on completion of support form', async () => {
-        const listener = oneEvent(el, 'success');
-
-        const supportForm: SupportForm =
-          el.shadowRoot!.querySelector('support-form')!;
-        supportForm.valid = true;
-        supportForm.dispatchEvent(new CustomEvent('submit'));
-
-        const {detail} = await listener;
-        expect(detail).toBeNull();
-      });
-
-      it('emits failure event when feedback reporting fails', async () => {
-        const listener = oneEvent(el, 'error');
-        mockErrorReporter.sendFeedback.and.throwError('fail');
-
-        const supportForm: SupportForm =
-          el.shadowRoot!.querySelector('support-form')!;
-        supportForm.valid = true;
-        supportForm.dispatchEvent(new CustomEvent('submit'));
-
-        const {detail} = await listener;
-        expect(detail).toBeNull();
-      });
-
-      it('shows default contact view on cancellation of support form', async () => {
-        el.shadowRoot!.querySelector('support-form')!.dispatchEvent(
-          new CustomEvent('cancel')
-        );
-
-        await nextFrame();
-
-        expect(el.shadowRoot?.querySelector('p.intro')?.textContent).toContain(
-          'Tell us how we can help.'
-        );
-        expect(el.shadowRoot?.querySelector('support-form')).toBeNull();
-      });
+      const {detail} = await listener;
+      expect(detail).toBeNull();
     });
   });
 });

--- a/client/web/views/contact_view/index.ts
+++ b/client/web/views/contact_view/index.ts
@@ -14,59 +14,26 @@
  * limitations under the License.
  */
 
-// TODO: Remove this entire contact-us view once
-// https://github.com/OutlineFoundation/outline-apps/pull/2739 is merged.
-
 import {SingleSelectedEvent} from '@material/mwc-list/mwc-list';
-import {Radio} from '@material/mwc-radio';
 import '@material/mwc-circular-progress';
-import '@material/mwc-radio';
 import '@material/mwc-select';
-import '@material/mwc-formfield';
 
 import {Localizer} from '@outline/infrastructure/i18n';
-import {html, css, LitElement, TemplateResult, nothing} from 'lit';
+import {html, css, LitElement} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {Ref, createRef, ref} from 'lit/directives/ref.js';
-import {unsafeHTML} from 'lit/directives/unsafe-html.js';
 
 import './support_form';
 import {FormValues, SupportForm} from './support_form';
 import {OutlineErrorReporter} from '../../shared/error_reporter';
 
-/** The possible steps in the stepper. Only one step is shown at a time. */
-enum ProgressStep {
-  ISSUE_WIZARD, // Step to ask for their specific issue.
-  FORM, // The contact form.
-  EXIT, // Final message to show, if any.
-}
-
 /** Supported issue types in the feedback flow. */
 enum IssueType {
-  NO_SERVER = 'no-server',
   CANNOT_ADD_SERVER = 'cannot-add-server',
-  BILLING = 'billing',
   CONNECTION = 'connection',
   PERFORMANCE = 'performance',
   GENERAL = 'general',
 }
-
-/** A map of unsupported issue types to helppage URLs to redirect users to. */
-const UNSUPPORTED_ISSUE_TYPES = new Map([
-  [
-    IssueType.NO_SERVER,
-    'https://support.getoutline.org/client/getting-started/get-access-key',
-  ],
-  [
-    IssueType.CANNOT_ADD_SERVER,
-    'https://support.getoutline.org/client/troubleshooting/access-key-issues',
-  ],
-  [IssueType.BILLING, null],
-  [
-    IssueType.CONNECTION,
-    'https://support.getoutline.org/client/troubleshooting/connection-issues',
-  ],
-]);
 
 @customElement('contact-view')
 export class ContactView extends LitElement {
@@ -98,13 +65,6 @@ export class ContactView extends LitElement {
         margin-top: 0.25rem;
       }
 
-      ol {
-        list-style-type: none;
-        margin: 1.5rem 0;
-        padding-inline-start: 0;
-        color: var(--outline-text-color);
-      }
-
       mwc-select {
         /**
          * The '<app-header-layout>' restricts the stacking context, which means
@@ -133,10 +93,6 @@ export class ContactView extends LitElement {
         border-radius: 4px;
         padding: 4px 0;
         margin-top: 16px;
-      }
-
-      mwc-select[hidden] {
-        display: none;
       }
 
       /* Style the dropdown list */
@@ -175,28 +131,6 @@ export class ContactView extends LitElement {
         width: 100%;
       }
 
-      /* Fix radio buttons */
-      mwc-radio {
-        --mdc-theme-secondary: var(--outline-primary);
-        --mdc-radio-unchecked-color: var(--outline-text-color);
-        --mdc-radio-unchecked-color: var(--outline-text-color);
-        --mdc-theme-secondary: var(--outline-primary);
-        --mdc-radio-disabled-color: var(--outline-label-color);
-        border-color: var(--outline-text-color);
-      }
-
-      mwc-formfield {
-        color: var(--outline-text-color);
-        --mdc-theme-text-primary-on-background: var(--outline-text-color);
-      }
-
-      .formfield {
-        color: var(--outline-text-color);
-        --mdc-theme-text-primary-on-background: var(--outline-text-color);
-        font-weight: normal;
-        padding: 8px 0;
-      }
-
       /* Style links for better visibility in dark mode */
       a {
         color: var(--outline-primary);
@@ -206,88 +140,31 @@ export class ContactView extends LitElement {
   ];
 
   private static readonly ISSUES: IssueType[] = [
-    IssueType.NO_SERVER,
     IssueType.CANNOT_ADD_SERVER,
-    IssueType.BILLING,
     IssueType.CONNECTION,
     IssueType.PERFORMANCE,
     IssueType.GENERAL,
   ];
 
   @property({type: Object}) localize: Localizer = msg => msg;
-  @property({type: String}) languageCode = '';
   @property({type: Object, attribute: 'error-reporter'})
   errorReporter: OutlineErrorReporter;
 
-  @state() private currentStep: ProgressStep = ProgressStep.ISSUE_WIZARD;
-  private selectedIssueType?: IssueType;
-  private exitTemplate?: TemplateResult;
-
-  private readonly openTicketSelectionOptions: Array<{
-    ref: Ref<Radio>;
-    value: boolean;
-    labelMsg: string;
-  }> = [
-    {
-      ref: createRef(),
-      value: true,
-      labelMsg: 'yes',
-    },
-    {
-      ref: createRef(),
-      value: false,
-      labelMsg: 'no',
-    },
-  ];
-
-  @state() private showIssueSelector = false;
+  @state() private selectedIssueType: IssueType = IssueType.GENERAL;
   private formValues: Partial<FormValues> = {};
   private readonly formRef: Ref<SupportForm> = createRef();
   @state() private isFormSubmitting = false;
 
-  private selectHasOpenTicket(e: InputEvent) {
-    const radio = e.target as Radio;
-    const hasOpenTicket = radio.value;
-    if (hasOpenTicket) {
-      this.exitTemplate = html`${this.localize(
-        'contact-view-exit-open-ticket'
-      )}`;
-      this.currentStep = ProgressStep.EXIT;
-      return;
-    }
-    this.showIssueSelector = true;
-  }
-
   private selectIssue(e: SingleSelectedEvent) {
-    this.selectedIssueType = ContactView.ISSUES[e.detail.index];
-
-    if (UNSUPPORTED_ISSUE_TYPES.has(this.selectedIssueType)) {
-      const helpPage = UNSUPPORTED_ISSUE_TYPES.get(this.selectedIssueType);
-      if (helpPage) {
-        this.exitTemplate = this.localizeWithUrl(
-          `contact-view-exit-${this.selectedIssueType}`,
-          helpPage
-        );
-      } else {
-        this.exitTemplate = html`${this.localize(
-          `contact-view-exit-${this.selectedIssueType}`
-        )}`;
-      }
-      this.currentStep = ProgressStep.EXIT;
+    if (e.detail.index === -1) {
       return;
     }
-
-    this.currentStep = ProgressStep.FORM;
+    this.selectedIssueType = ContactView.ISSUES[e.detail.index];
   }
 
   reset() {
     this.isFormSubmitting = false;
-    this.showIssueSelector = false;
-    this.openTicketSelectionOptions.forEach(element => {
-      if (!element.ref.value) return;
-      element.ref.value.checked = false;
-    });
-    this.currentStep = ProgressStep.ISSUE_WIZARD;
+    this.selectedIssueType = IssueType.GENERAL;
     this.formValues = {};
   }
 
@@ -321,99 +198,45 @@ export class ContactView extends LitElement {
     this.dispatchEvent(new CustomEvent('success'));
   }
 
-  private localizeWithUrl(messageID: string, url: string): TemplateResult {
-    const parsedUrl = new URL(url);
-    if (this.languageCode) {
-      parsedUrl.searchParams.append('language', this.languageCode);
-    }
-    const openLink = `<a href="${parsedUrl.toString()}" target="_blank">`;
-    const closeLink = '</a>';
-    return html`
-      ${unsafeHTML(
-        this.localize(messageID, 'openLink', openLink, 'closeLink', closeLink)
-      )}
-    `;
-  }
-
-  private get renderIntroTemplate(): TemplateResult {
-    return html`<p class="intro">${this.localize('contact-view-intro')}</p>`;
-  }
-
-  private get renderForm(): TemplateResult | typeof nothing {
+  render() {
     if (this.isFormSubmitting) {
       return html`
-        <mwc-circular-progress indeterminate></mwc-circular-progress>
+        <main>
+          <mwc-circular-progress indeterminate></mwc-circular-progress>
+        </main>
       `;
     }
+
     return html`
-      <support-form
-        ${ref(this.formRef)}
-        .localize=${this.localize}
-        .disabled=${this.isFormSubmitting}
-        .values=${this.formValues}
-        @cancel=${this.reset}
-        @submit=${this.submitForm}
-      ></support-form>
+      <main>
+        <p class="intro">${this.localize('contact-view-intro')}</p>
+
+        <mwc-select
+          .label=${this.localize('contact-view-issue')}
+          ?fixedMenuPosition=${true}
+          @selected="${this.selectIssue}"
+        >
+          ${ContactView.ISSUES.map(value => {
+            return html`
+              <mwc-list-item
+                value="${value}"
+                ?selected=${value === this.selectedIssueType}
+              >
+                <span>${this.localize(`contact-view-issue-${value}`)}</span>
+              </mwc-list-item>
+            `;
+          })}
+        </mwc-select>
+
+        <support-form
+          ${ref(this.formRef)}
+          .localize=${this.localize}
+          .disabled=${this.isFormSubmitting}
+          .values=${this.formValues}
+          @cancel=${this.reset}
+          @submit=${this.submitForm}
+        ></support-form>
+      </main>
     `;
-  }
-
-  private get renderMainContent(): TemplateResult {
-    switch (this.currentStep) {
-      case ProgressStep.FORM: {
-        return html` ${this.renderIntroTemplate} ${this.renderForm} `;
-      }
-
-      case ProgressStep.EXIT: {
-        return html` <p class="exit">${this.exitTemplate}</p>`;
-      }
-
-      case ProgressStep.ISSUE_WIZARD:
-      default: {
-        return html`
-          ${this.renderIntroTemplate}
-
-          <p>${this.localize('contact-view-open-ticket')}</p>
-
-          <ol>
-            ${this.openTicketSelectionOptions.map(
-              element => html`
-                <li>
-                  <mwc-formfield .label=${this.localize(element.labelMsg)}>
-                    <!-- mwc-radio's 'value' attribute is incorrectly typed as a string - if you pass a string, it breaks -->
-                    <mwc-radio
-                      name="open-ticket"
-                      .value="${element.value as unknown as string}"
-                      required
-                      @change=${this.selectHasOpenTicket}
-                      ${ref(element.ref)}
-                    >
-                    </mwc-radio>
-                  </mwc-formfield>
-                </li>
-              `
-            )}
-          </ol>
-
-          <mwc-select
-            .label=${this.localize('contact-view-issue')}
-            ?hidden=${!this.showIssueSelector}
-            ?fixedMenuPosition=${true}
-            @selected="${this.selectIssue}"
-          >
-            ${ContactView.ISSUES.map(value => {
-              return html`
-                <mwc-list-item value="${value}">
-                  <span>${this.localize(`contact-view-issue-${value}`)}</span>
-                </mwc-list-item>
-              `;
-            })}
-          </mwc-select>
-        `;
-      }
-    }
-  }
-
-  render() {
-    return html`<main>${this.renderMainContent}</main>`;
   }
 }

--- a/client/web/views/contact_view/support_form/index.spec.ts
+++ b/client/web/views/contact_view/support_form/index.spec.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {TextArea} from '@material/mwc-textarea';
 import {TextField} from '@material/mwc-textfield';
 
 import {
@@ -27,7 +28,7 @@ import {
 
 import {FormValues, SupportForm} from './index';
 
-async function setValue(el: TextField, value: string) {
+async function setValue(el: TextField | TextArea, value: string) {
   await triggerFocusFor(el);
   el.value = value;
   await triggerBlurFor(el);
@@ -43,10 +44,7 @@ describe('SupportForm', () => {
   it('sets fields with provided form values', async () => {
     const values: FormValues = {
       email: 'foo@bar.com',
-      accessKeySource: 'a friend',
-      subject: 'Test Subject',
       description: 'Test Description',
-      outreachConsent: false,
     };
     const el = await fixture(html`
       <support-form .values=${values}></support-form>
@@ -56,15 +54,7 @@ describe('SupportForm', () => {
       'mwc-textfield[name="email"'
     )!;
     expect(emailInput.value).toBe('foo@bar.com');
-    const accessKeySourceInput: TextField = el.shadowRoot!.querySelector(
-      'mwc-textfield[name="accessKeySource"'
-    )!;
-    expect(accessKeySourceInput.value).toBe('a friend');
-    const subjectInput: TextField = el.shadowRoot!.querySelector(
-      'mwc-textfield[name="subject"'
-    )!;
-    expect(subjectInput.value).toBe('Test Subject');
-    const descriptionInput: TextField = el.shadowRoot!.querySelector(
+    const descriptionInput: TextArea = el.shadowRoot!.querySelector(
       'mwc-textarea[name="description"'
     )!;
     expect(descriptionInput.value).toBe('Test Description');
@@ -93,6 +83,19 @@ describe('SupportForm', () => {
     expect(submitButton.hasAttribute('disabled')).toBeTrue();
   });
 
+  it('is valid without an email, since it is optional', async () => {
+    const el: SupportForm = await fixture(html`
+      <support-form></support-form>
+    `);
+    const descriptionInput: TextArea = el.shadowRoot!.querySelector(
+      'mwc-textarea[name="description"'
+    )!;
+    await setValue(descriptionInput, 'Test Description');
+    await nextFrame();
+
+    expect(el.valid).toBeTrue();
+  });
+
   describe('when form is valid', () => {
     let el: SupportForm;
     let submitButton: HTMLElement;
@@ -104,15 +107,7 @@ describe('SupportForm', () => {
         'mwc-textfield[name="email"'
       )!;
       await setValue(emailInput, 'foo@bar.com');
-      const accessKeySourceInput: TextField = el.shadowRoot!.querySelector(
-        'mwc-textfield[name="accessKeySource"'
-      )!;
-      await setValue(accessKeySourceInput, 'From a friend');
-      const subjectInput: TextField = el.shadowRoot!.querySelector(
-        'mwc-textfield[name="subject"'
-      )!;
-      await setValue(subjectInput, 'Test Subject');
-      const descriptionInput: TextField = el.shadowRoot!.querySelector(
+      const descriptionInput: TextArea = el.shadowRoot!.querySelector(
         'mwc-textarea[name="description"'
       )!;
       await setValue(descriptionInput, 'Test Description');

--- a/client/web/views/contact_view/support_form/index.ts
+++ b/client/web/views/contact_view/support_form/index.ts
@@ -16,11 +16,8 @@
 
 import {TextArea} from '@material/mwc-textarea';
 import {TextField} from '@material/mwc-textfield';
-import '@material/web/checkbox/checkbox';
-import {MdCheckbox} from '@material/web/checkbox/checkbox';
 
 import '@material/mwc-button';
-import '@material/mwc-select';
 import '@material/mwc-textarea';
 import '@material/mwc-textfield';
 import {Localizer} from '@outline/infrastructure/i18n';
@@ -33,11 +30,8 @@ type FormControl = HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
 
 /** Interface for tracking form data. */
 export declare interface FormValues {
-  email: string;
-  subject: string;
+  email?: string;
   description: string;
-  accessKeySource: string;
-  outreachConsent: boolean;
 }
 
 @customElement('support-form')
@@ -54,14 +48,6 @@ export class SupportForm extends LitElement {
         color: var(--outline-text-color);
       }
 
-      mwc-select {
-        width: 100%;
-        --mdc-select-ink-color: var(--outline-text-color);
-        --mdc-select-label-ink-color: var(--outline-label-color);
-        --mdc-select-dropdown-icon-color: var(--outline-text-color);
-        --mdc-select-hover-line-color: var(--outline-text-color);
-      }
-
       mwc-textarea,
       mwc-textfield {
         display: flex;
@@ -73,30 +59,9 @@ export class SupportForm extends LitElement {
         --mdc-text-field-disabled-ink-color: var(--outline-label-color);
       }
 
-      label {
-        align-items: center;
-        display: inline-flex;
-        color: var(--outline-text-color);
-      }
-      label md-checkbox {
-        flex-shrink: 0;
-        --md-sys-color-on-primary: var(--outline-card-background);
-      }
-
-      md-checkbox {
-        --md-sys-color-primary: var(--outline-primary);
-        --md-sys-color-outline: var(--outline-text-color);
-      }
-
       mwc-button {
         --mdc-theme-primary: var(--outline-primary);
         --mdc-theme-on-primary: var(--outline-card-background);
-      }
-
-      p {
-        color: var(--outline-label-color);
-        font-size: 0.8rem;
-        text-align: end;
       }
 
       .actions {
@@ -130,6 +95,12 @@ export class SupportForm extends LitElement {
 
   /** Checks the entire form's validity state. */
   private checkFormValidity() {
+    // The form ref is unset while the element is disconnected (e.g. when the
+    // host swaps the form out for a progress spinner during submission), but a
+    // queued validity check may still fire. Bail out rather than throwing.
+    if (!this.formRef.value) {
+      return;
+    }
     const fieldNodes =
       this.formRef.value.querySelectorAll<FormControl>('*[name]');
     this.valid = Array.from(fieldNodes).every(field => field.validity.valid);
@@ -156,12 +127,8 @@ export class SupportForm extends LitElement {
     const target = e.target as HTMLInputElement;
     const key = target.name as keyof FormValues;
     if (target instanceof TextField || target instanceof TextArea) {
-      const key = target.name as keyof FormValues;
       const {value} = target;
       (this.values as Record<string, string>)[key] = value;
-    } else if (target instanceof MdCheckbox) {
-      const {checked: value} = target as MdCheckbox;
-      (this.values as Record<string, boolean>)[key] = value;
     } else {
       throw new Error(`Cannot handle unknown form field: ${key}`);
     }
@@ -180,32 +147,10 @@ export class SupportForm extends LitElement {
           autoValidate
           .validationMessage=${this.localize('support-form-email-invalid')}
           .disabled=${this.disabled}
-          required
           @input=${this.handleInput}
           @blur=${this.checkFormValidity}
         ></mwc-textfield>
 
-        <mwc-textfield
-          name="accessKeySource"
-          .label=${this.localize('support-form-access-key-source')}
-          .value=${live(this.values.accessKeySource ?? '')}
-          .maxLength=${SupportForm.DEFAULT_MAX_LENGTH_INPUT}
-          .disabled=${this.disabled}
-          required
-          @input=${this.handleInput}
-          @blur=${this.checkFormValidity}
-        ></mwc-textfield>
-
-        <mwc-textfield
-          name="subject"
-          .label=${this.localize('support-form-subject')}
-          .value=${live(this.values.subject ?? '')}
-          .maxLength=${SupportForm.DEFAULT_MAX_LENGTH_INPUT}
-          .disabled=${this.disabled}
-          required
-          @input=${this.handleInput}
-          @blur=${this.checkFormValidity}
-        ></mwc-textfield>
         <mwc-textarea
           name="description"
           .label=${this.localize('support-form-description')}
@@ -218,18 +163,6 @@ export class SupportForm extends LitElement {
           @blur=${this.checkFormValidity}
         >
         </mwc-textarea>
-
-        <label style="color: var(--outline-text-color);">
-          <md-checkbox
-            touch-target="wrapper"
-            name="outreachConsent"
-            .value=${live(String(this.values.outreachConsent ?? false))}
-            @input=${this.handleInput}
-          ></md-checkbox>
-          ${this.localize('support-form-outreach-consent')}
-        </label>
-
-        <p>* = ${this.localize('support-form-required-field')}</p>
 
         <span class="actions">
           <mwc-button

--- a/client/web/views/contact_view/support_form/stories.ts
+++ b/client/web/views/contact_view/support_form/stories.ts
@@ -64,10 +64,7 @@ export const CompleteForm = ({
 }) => {
   const values: FormValues = {
     email: 'foo@bar.com',
-    subject: 'My Test Subject',
     description: 'My Test Description',
-    accessKeySource: 'a friend',
-    outreachConsent: true,
   };
   return html`
     <support-form


### PR DESCRIPTION
Client counterpart to #2754 (which did this for the manager). Replaces the multi-step "Contact Us" wizard with a single, direct feedback form — a category selector, an optional email, and the feedback text. Now it mirrors the "Contact Us" form used in the manager.

### Changes
- **`contact_view`**: dropped the "do you have an open ticket?" question, the issue-type help-page redirects, and the exit step. The category selector and support form now render together; the selected category (default `general`) is passed to `sendFeedback`. The category list is trimmed from six to four:
  - **Kept:**
    - `cannot-add-server` — "I am having trouble adding a server using my access key"
    - `connection` — "I am having trouble connecting to my Outline VPN server"
    - `performance` — "My internet access is slow while connected to my Outline VPN server"
    - `general` — "General feedback & suggestions"
  - **Dropped:**
    - `no-server` — "I need an access key"
    - `billing` — "I need assistance with a billing or subscription issue"
- **`support_form`**: reduced to an optional email and the feedback text — removed the subject, access-key-source and outreach-consent fields and the redundant "* = Required field" note. Also guarded `checkFormValidity()` against running while the form is disconnected (it is swapped for a progress spinner during submission), which was otherwise throwing uncaught.
- Removed the now-unused `languageCode` property and its `language-code` binding in `app-root.js`.

Stacked on the strings PR #2822, where the "Contact us" → "Feedback" rename and the localized message updates live.

### Tested

Sent sentry feedback through android emulator build: https://outlinevpn.sentry.io/issues/7649595897/?project=159502

### Screenshots

<img width="750" height="1624" alt="01-nav-feedback" src="https://github.com/user-attachments/assets/8d29782c-fca6-4b77-ad78-75dffc5f2eb5" />
<img width="750" height="1624" alt="02-feedback-form" src="https://github.com/user-attachments/assets/b9aabe4f-0b9f-4ff7-904b-44fccfc5df93" />
<img width="750" height="1624" alt="03-category-open" src="https://github.com/user-attachments/assets/ba0d6240-be5a-4068-a2dc-24edd6f10c74" />


