### PR TITLE
fix(client): keep native debug symbols and upload them to Sentry [1/2]

### DIFF
--- a/client/go/Taskfile.yml
+++ b/client/go/Taskfile.yml
@@ -21,23 +21,20 @@ vars:
   OUT_DIR: '{{joinPath .REPO_ROOT "output/client"}}'
   BIN_DIR: '{{joinPath .OUT_DIR "/bin"}}'
   MOBILE_PKG: "{{.TASKFILE_DIR}}/outline/tun2socks"
-  # Android gomobile bind that keeps native debug info so crashes inside
-  # libgojni.so can be symbolicated in Sentry. Unlike a stripped build:
+  # gomobile bind that keeps native debug info so crashes in the bound library
+  # (Android libgojni.so, Apple Tun2socks.xcframework) can be symbolicated in
+  # Sentry. Unlike a stripped build:
   #   - No `-ldflags='-s -w'`: `-s` strips the symbol table, `-w` strips DWARF.
-  #     Omitting both leaves symtab + DWARF in the .so, which sentry-cli needs
-  #     (a stripped .so uploads but resolves nothing).
+  #     Omitting both leaves symtab + DWARF in the output, which sentry-cli
+  #     needs (a stripped binary uploads but resolves nothing).
   #   - `-g` in CGO_CFLAGS: emits DWARF for the cgo/C frames too (e.g. lwIP's
   #     udp_input), not just the Go frames.
-  # The unstripped .so is uploaded to Sentry as a debug file by the
-  # client/src/cordova/upload_debug_symbols action; the Android Gradle Plugin
-  # still strips the copy packaged into the shipped APK, so app size is
-  # unaffected.
-  GOMOBILE_BIND_CMD_ANDROID: "env PATH=\"{{.BIN_DIR}}:${PATH}\" CGO_CFLAGS='-fstack-protector-strong -g' '{{.BIN_DIR}}/gomobile' bind"
-  # Apple build variant, same rationale as GOMOBILE_BIND_CMD_ANDROID: keep the
-  # symbol table + DWARF (no `-s -w`) and add `-g` for the cgo/C frames, so
-  # Xcode's archive step produces dSYMs that resolve native (Go) frames. The
-  # dSYMs are uploaded to Sentry by the upload_debug_symbols action.
-  GOMOBILE_BIND_CMD_APPLE: "env PATH=\"{{.BIN_DIR}}:${PATH}\" CGO_CFLAGS='-fstack-protector-strong -g' '{{.BIN_DIR}}/gomobile' bind"
+  # The debug files are uploaded to Sentry by the
+  # client/src/cordova/upload_debug_symbols action (Android: the unstripped .so
+  # from the .aar; Apple: the archive's dSYMs). Shipped app size is unaffected:
+  # the Android Gradle Plugin strips the copy packaged into the APK, and Apple
+  # dSYMs live outside the app bundle.
+  GOMOBILE_BIND_CMD: "env PATH=\"{{.BIN_DIR}}:${PATH}\" CGO_CFLAGS='-fstack-protector-strong -g' '{{.BIN_DIR}}/gomobile' bind"
 
 tasks:
   electron:
@@ -111,7 +108,7 @@ tasks:
       - '{{.OUT_DIR}}/android/.env'
     cmds:
       - rm -rf "{{.TARGET_DIR}}" && mkdir -p "{{.TARGET_DIR}}"
-      - "{{.GOMOBILE_BIND_CMD_ANDROID}} -target=android -androidapi '{{.ANDROID_API}}' -o '{{.TARGET_DIR}}/tun2socks-0.0.1.aar' '{{.TASKFILE_DIR}}/outline/platerrors' '{{.TASKFILE_DIR}}/outline/tun2socks' '{{.TASKFILE_DIR}}/outline'"
+      - "{{.GOMOBILE_BIND_CMD}} -target=android -androidapi '{{.ANDROID_API}}' -o '{{.TARGET_DIR}}/tun2socks-0.0.1.aar' '{{.TASKFILE_DIR}}/outline/platerrors' '{{.TASKFILE_DIR}}/outline/tun2socks' '{{.TASKFILE_DIR}}/outline'"
       - echo $'<?xml version="1.0" encoding="UTF-8"?>\n<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\n  <modelVersion>4.0.0</modelVersion>\n  <groupId>org.getoutline.client</groupId>\n  <artifactId>tun2socks</artifactId>\n  <version>0.0.1</version>\n  <packaging>aar</packaging>\n</project>' > "{{.TARGET_DIR}}/tun2socks-0.0.1.pom"
     deps: ["gomobile", ":client:android:configure"]
 
@@ -129,7 +126,7 @@ tasks:
       GODEBUG: gotypesalias=0
     cmds:
       - rm -rf "{{.TARGET_DIR}}" && mkdir -p "{{.TARGET_DIR}}"
-      - export MACOSX_DEPLOYMENT_TARGET={{.MACOSX_DEPLOYMENT_TARGET}}; {{.GOMOBILE_BIND_CMD_APPLE}} -target=ios,iossimulator,maccatalyst -iosversion={{.TARGET_IOS_VERSION}} -bundleid org.outline.tun2socks -o '{{.TARGET_DIR}}/Tun2socks.xcframework' '{{.TASKFILE_DIR}}/outline/platerrors' '{{.TASKFILE_DIR}}/outline/tun2socks' '{{.TASKFILE_DIR}}/outline'
+      - export MACOSX_DEPLOYMENT_TARGET={{.MACOSX_DEPLOYMENT_TARGET}}; {{.GOMOBILE_BIND_CMD}} -target=ios,iossimulator,maccatalyst -iosversion={{.TARGET_IOS_VERSION}} -bundleid org.outline.tun2socks -o '{{.TARGET_DIR}}/Tun2socks.xcframework' '{{.TASKFILE_DIR}}/outline/platerrors' '{{.TASKFILE_DIR}}/outline/tun2socks' '{{.TASKFILE_DIR}}/outline'
     deps: ["gomobile"]
 
   browser:

--- a/client/go/Taskfile.yml
+++ b/client/go/Taskfile.yml
@@ -21,9 +21,8 @@ vars:
   OUT_DIR: '{{joinPath .REPO_ROOT "output/client"}}'
   BIN_DIR: '{{joinPath .OUT_DIR "/bin"}}'
   MOBILE_PKG: "{{.TASKFILE_DIR}}/outline/tun2socks"
-  GOMOBILE_BIND_CMD: "env PATH=\"{{.BIN_DIR}}:${PATH}\" CGO_CFLAGS='-fstack-protector-strong' '{{.BIN_DIR}}/gomobile' bind -ldflags='-s -w'"
-  # Android build variant that keeps native debug info so crashes inside
-  # libgojni.so can be symbolicated in Sentry. Differences from the default:
+  # Android gomobile bind that keeps native debug info so crashes inside
+  # libgojni.so can be symbolicated in Sentry. Unlike a stripped build:
   #   - No `-ldflags='-s -w'`: `-s` strips the symbol table, `-w` strips DWARF.
   #     Omitting both leaves symtab + DWARF in the .so, which sentry-cli needs
   #     (a stripped .so uploads but resolves nothing).
@@ -34,6 +33,11 @@ vars:
   # still strips the copy packaged into the shipped APK, so app size is
   # unaffected.
   GOMOBILE_BIND_CMD_ANDROID: "env PATH=\"{{.BIN_DIR}}:${PATH}\" CGO_CFLAGS='-fstack-protector-strong -g' '{{.BIN_DIR}}/gomobile' bind"
+  # Apple build variant, same rationale as GOMOBILE_BIND_CMD_ANDROID: keep the
+  # symbol table + DWARF (no `-s -w`) and add `-g` for the cgo/C frames, so
+  # Xcode's archive step produces dSYMs that resolve native (Go) frames. The
+  # dSYMs are uploaded to Sentry by the upload_debug_symbols action.
+  GOMOBILE_BIND_CMD_APPLE: "env PATH=\"{{.BIN_DIR}}:${PATH}\" CGO_CFLAGS='-fstack-protector-strong -g' '{{.BIN_DIR}}/gomobile' bind"
 
 tasks:
   electron:
@@ -55,17 +59,21 @@ tasks:
       #   Windows: requires 32-bit
       #   Linux: requires older glibc for wider compatibility
       # Linker flags: https://pkg.go.dev/cmd/link
-      #   -s Omit the symbol table and debug information.
-      #   -w Omit the DWARF symbol table.
       #   -X Set the value of the string variable.
+      # We intentionally do NOT pass `-s -w`: `-s` strips the symbol table and
+      # `-w` strips DWARF. Keeping both leaves the debug info that sentry-cli
+      # needs to symbolicate native crashes in the desktop tun2socks binary and
+      # backend library; these files are uploaded to Sentry by the
+      # client/src/cordova/upload_debug_symbols action. The desktop package ships
+      # the unstripped binaries (the size delta is negligible next to Electron).
       - |
         GOOS={{.TARGET_OS}} GOARCH={{.TARGET_ARCH}} CGO_ENABLED=1 \
         CC='zig cc -target {{.ZIG_TARGET}}' \
-        go build -trimpath -ldflags="-s -w -X=main.version={{.TUN2SOCKS_VERSION}}" -o '{{.OUTPUT}}' '{{.TASKFILE_DIR}}/outline/electron'
+        go build -trimpath -ldflags="-X=main.version={{.TUN2SOCKS_VERSION}}" -o '{{.OUTPUT}}' '{{.TASKFILE_DIR}}/outline/electron'
       - |
         GOOS={{.TARGET_OS}} GOARCH={{.TARGET_ARCH}} CGO_ENABLED=1 \
         CC='zig cc -target {{.ZIG_TARGET}}' \
-        go build -trimpath -buildmode=c-shared -ldflags="-s -w -X=main.version={{.TUN2SOCKS_VERSION}}" -o '{{.OUTPUT_LIB}}' '{{.TASKFILE_DIR}}/outline/electron'
+        go build -trimpath -buildmode=c-shared -ldflags="-X=main.version={{.TUN2SOCKS_VERSION}}" -o '{{.OUTPUT_LIB}}' '{{.TASKFILE_DIR}}/outline/electron'
 
   windows:
     deps: [windows:386]
@@ -121,7 +129,7 @@ tasks:
       GODEBUG: gotypesalias=0
     cmds:
       - rm -rf "{{.TARGET_DIR}}" && mkdir -p "{{.TARGET_DIR}}"
-      - export MACOSX_DEPLOYMENT_TARGET={{.MACOSX_DEPLOYMENT_TARGET}}; {{.GOMOBILE_BIND_CMD}} -target=ios,iossimulator,maccatalyst -iosversion={{.TARGET_IOS_VERSION}} -bundleid org.outline.tun2socks -o '{{.TARGET_DIR}}/Tun2socks.xcframework' '{{.TASKFILE_DIR}}/outline/platerrors' '{{.TASKFILE_DIR}}/outline/tun2socks' '{{.TASKFILE_DIR}}/outline'
+      - export MACOSX_DEPLOYMENT_TARGET={{.MACOSX_DEPLOYMENT_TARGET}}; {{.GOMOBILE_BIND_CMD_APPLE}} -target=ios,iossimulator,maccatalyst -iosversion={{.TARGET_IOS_VERSION}} -bundleid org.outline.tun2socks -o '{{.TARGET_DIR}}/Tun2socks.xcframework' '{{.TASKFILE_DIR}}/outline/platerrors' '{{.TASKFILE_DIR}}/outline/tun2socks' '{{.TASKFILE_DIR}}/outline'
     deps: ["gomobile"]
 
   browser:

--- a/client/go/Taskfile.yml
+++ b/client/go/Taskfile.yml
@@ -22,6 +22,18 @@ vars:
   BIN_DIR: '{{joinPath .OUT_DIR "/bin"}}'
   MOBILE_PKG: "{{.TASKFILE_DIR}}/outline/tun2socks"
   GOMOBILE_BIND_CMD: "env PATH=\"{{.BIN_DIR}}:${PATH}\" CGO_CFLAGS='-fstack-protector-strong' '{{.BIN_DIR}}/gomobile' bind -ldflags='-s -w'"
+  # Android build variant that keeps native debug info so crashes inside
+  # libgojni.so can be symbolicated in Sentry. Differences from the default:
+  #   - No `-ldflags='-s -w'`: `-s` strips the symbol table, `-w` strips DWARF.
+  #     Omitting both leaves symtab + DWARF in the .so, which sentry-cli needs
+  #     (a stripped .so uploads but resolves nothing).
+  #   - `-g` in CGO_CFLAGS: emits DWARF for the cgo/C frames too (e.g. lwIP's
+  #     udp_input), not just the Go frames.
+  # The unstripped .so is uploaded to Sentry as a debug file by the
+  # client/src/cordova/upload_debug_symbols action; the Android Gradle Plugin
+  # still strips the copy packaged into the shipped APK, so app size is
+  # unaffected.
+  GOMOBILE_BIND_CMD_ANDROID: "env PATH=\"{{.BIN_DIR}}:${PATH}\" CGO_CFLAGS='-fstack-protector-strong -g' '{{.BIN_DIR}}/gomobile' bind"
 
 tasks:
   electron:
@@ -91,7 +103,7 @@ tasks:
       - '{{.OUT_DIR}}/android/.env'
     cmds:
       - rm -rf "{{.TARGET_DIR}}" && mkdir -p "{{.TARGET_DIR}}"
-      - "{{.GOMOBILE_BIND_CMD}} -target=android -androidapi '{{.ANDROID_API}}' -o '{{.TARGET_DIR}}/tun2socks-0.0.1.aar' '{{.TASKFILE_DIR}}/outline/platerrors' '{{.TASKFILE_DIR}}/outline/tun2socks' '{{.TASKFILE_DIR}}/outline'"
+      - "{{.GOMOBILE_BIND_CMD_ANDROID}} -target=android -androidapi '{{.ANDROID_API}}' -o '{{.TARGET_DIR}}/tun2socks-0.0.1.aar' '{{.TASKFILE_DIR}}/outline/platerrors' '{{.TASKFILE_DIR}}/outline/tun2socks' '{{.TASKFILE_DIR}}/outline'"
       - echo $'<?xml version="1.0" encoding="UTF-8"?>\n<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\n  <modelVersion>4.0.0</modelVersion>\n  <groupId>org.getoutline.client</groupId>\n  <artifactId>tun2socks</artifactId>\n  <version>0.0.1</version>\n  <packaging>aar</packaging>\n</project>' > "{{.TARGET_DIR}}/tun2socks-0.0.1.pom"
     deps: ["gomobile", ":client:android:configure"]
 

--- a/client/src/cordova/upload_debug_symbols.action.mjs
+++ b/client/src/cordova/upload_debug_symbols.action.mjs
@@ -29,6 +29,10 @@ import {getBuildParameters} from '../../build/get_build_parameters.mjs';
 const DEFAULT_SENTRY_ORG = 'outlinevpn';
 const DEFAULT_SENTRY_PROJECT = 'outline-clients';
 
+// Temp directories created while collecting debug files (e.g. the Android .aar
+// extraction). They must outlive the upload, so main() removes them on exit.
+const tempDirs = [];
+
 /**
  * Resolve the sentry-cli binary. Prefer the path exported by the @sentry/cli
  * package so this works whether or not node_modules/.bin is on PATH; fall back
@@ -68,53 +72,61 @@ export async function main(...parameters) {
     return;
   }
 
-  const debugFiles = await collectDebugFiles(platform, goArch);
-  if (debugFiles === null) {
-    console.warn(
-      '[sentry] Native debug symbol upload is not implemented for platform ' +
-        `"${platform}"; skipping.`
-    );
-    return;
-  }
-  if (debugFiles.length === 0) {
-    throw new Error(
-      `[sentry] No native debug files were found for ${platform}. Expected at ` +
-        'least one binary with DWARF. Was the release build run first?'
-    );
-  }
-
-  // Verify every file actually carries usable debug info BEFORE uploading. A
-  // stripped binary uploads "successfully" but resolves nothing, so we fail the
-  // build here rather than ship a symbol pipeline that silently does nothing.
-  // dSYM bundles are directories; check the DWARF binaries inside them.
-  for (const file of debugFiles) {
-    for (const target of await resolveCheckTargets(file)) {
-      await assertUsableDebugFile(target);
+  try {
+    const debugFiles = await collectDebugFiles(platform, goArch);
+    if (debugFiles === null) {
+      console.warn(
+        '[sentry] Native debug symbol upload is not implemented for platform ' +
+          `"${platform}"; skipping.`
+      );
+      return;
     }
+    if (debugFiles.length === 0) {
+      throw new Error(
+        `[sentry] No native debug files were found for ${platform}. Expected at ` +
+          'least one binary with DWARF. Was the release build run first?'
+      );
+    }
+
+    // Verify every file actually carries usable debug info BEFORE uploading. A
+    // stripped binary uploads "successfully" but resolves nothing, so we fail the
+    // build here rather than ship a symbol pipeline that silently does nothing.
+    // dSYM bundles are directories; check the DWARF binaries inside them.
+    for (const file of debugFiles) {
+      for (const target of await resolveCheckTargets(file)) {
+        await assertUsableDebugFile(target);
+      }
+    }
+
+    const org = process.env.SENTRY_ORG || DEFAULT_SENTRY_ORG;
+    const project = process.env.SENTRY_PROJECT || DEFAULT_SENTRY_PROJECT;
+
+    await spawnStream(
+      resolveSentryCli(),
+      'debug-files',
+      'upload',
+      '--org',
+      org,
+      '--project',
+      project,
+      // Bundle the referenced native sources so Sentry can show source context in
+      // native stack frames (the analog of the Gradle plugin's
+      // includeNativeSources = true).
+      '--include-sources',
+      ...debugFiles
+    );
+
+    console.info(
+      `[sentry] Uploaded ${debugFiles.length} native debug file(s) for ` +
+        `${platform} to ${org}/${project}.`
+    );
+  } finally {
+    await Promise.all(
+      tempDirs
+        .splice(0)
+        .map(dir => fs.rm(dir, {recursive: true, force: true}))
+    );
   }
-
-  const org = process.env.SENTRY_ORG || DEFAULT_SENTRY_ORG;
-  const project = process.env.SENTRY_PROJECT || DEFAULT_SENTRY_PROJECT;
-
-  await spawnStream(
-    resolveSentryCli(),
-    'debug-files',
-    'upload',
-    '--org',
-    org,
-    '--project',
-    project,
-    // Bundle the referenced native sources so Sentry can show source context in
-    // native stack frames (the analog of the Gradle plugin's
-    // includeNativeSources = true).
-    '--include-sources',
-    ...debugFiles
-  );
-
-  console.info(
-    `[sentry] Uploaded ${debugFiles.length} native debug file(s) for ` +
-      `${platform} to ${org}/${project}.`
-  );
 }
 
 /**
@@ -164,6 +176,7 @@ async function collectAndroidDebugFiles() {
   const outDir = await fs.mkdtemp(
     path.join(os.tmpdir(), 'outline-android-syms-')
   );
+  tempDirs.push(outDir);
   // The .aar is a zip; jni/<abi>/libgojni.so holds the native code. Preserve the
   // jni/<abi>/ layout so same-named .so files across ABIs don't collide.
   await spawnStream('unzip', '-o', '-q', aar, 'jni/*', '-d', outDir);

--- a/client/src/cordova/upload_debug_symbols.action.mjs
+++ b/client/src/cordova/upload_debug_symbols.action.mjs
@@ -1,0 +1,225 @@
+// Copyright 2026 The Outline Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import fs from 'node:fs/promises';
+import {createRequire} from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import url from 'node:url';
+
+import {getRootDir} from '@outline/infrastructure/build/get_root_dir.mjs';
+import {spawnStream} from '@outline/infrastructure/build/spawn_stream.mjs';
+
+import {getBuildParameters} from '../../build/get_build_parameters.mjs';
+
+// Sentry destination. Authentication is handled by sentry-cli itself: it reads
+// a token from `sentry-cli login` (~/.sentryclirc) or from SENTRY_AUTH_TOKEN if
+// set, so no credential is ever passed in argv or handled here.
+const DEFAULT_SENTRY_ORG = 'outlinevpn';
+const DEFAULT_SENTRY_PROJECT = 'outline-clients';
+
+/**
+ * Resolve the sentry-cli binary. Prefer the path exported by the @sentry/cli
+ * package so this works whether or not node_modules/.bin is on PATH; fall back
+ * to the PATH lookup used by `npm run action`.
+ * @returns {string}
+ */
+function resolveSentryCli() {
+  try {
+    const require = createRequire(import.meta.url);
+    const {getPath} = require('@sentry/cli/js/helper');
+    const resolved = getPath();
+    if (resolved) {
+      return resolved;
+    }
+  } catch {
+    // Fall through to the PATH lookup.
+  }
+  return 'sentry-cli';
+}
+
+/**
+ * Uploads native debug information files (DIFs) for a release build to Sentry so
+ * native crashes (e.g. in libgojni.so) can be symbolicated. Only runs for
+ * release builds; it is invoked explicitly by the release pipeline, not from
+ * inside a build, so local and debug builds never reach it. sentry-cli supplies
+ * the credentials (see the note by DEFAULT_SENTRY_ORG).
+ *
+ * @param {string[]} parameters The list of action arguments passed in.
+ */
+export async function main(...parameters) {
+  const {platform, buildMode} = getBuildParameters(parameters);
+
+  if (buildMode !== 'release') {
+    console.debug(
+      `[sentry] Skipping native debug symbol upload for ${platform} (${buildMode} build).`
+    );
+    return;
+  }
+
+  const debugFiles = await collectDebugFiles(platform);
+  if (debugFiles === null) {
+    console.warn(
+      '[sentry] Native debug symbol upload is not implemented for platform ' +
+        `"${platform}"; skipping.`
+    );
+    return;
+  }
+  if (debugFiles.length === 0) {
+    throw new Error(
+      `[sentry] No native debug files were found for ${platform}. Expected at ` +
+        'least one binary with DWARF. Was the release build run first?'
+    );
+  }
+
+  // Verify every file actually carries usable debug info BEFORE uploading. A
+  // stripped binary uploads "successfully" but resolves nothing, so we fail the
+  // build here rather than ship a symbol pipeline that silently does nothing.
+  for (const file of debugFiles) {
+    await assertUsableDebugFile(file);
+  }
+
+  const org = process.env.SENTRY_ORG || DEFAULT_SENTRY_ORG;
+  const project = process.env.SENTRY_PROJECT || DEFAULT_SENTRY_PROJECT;
+
+  await spawnStream(
+    resolveSentryCli(),
+    'debug-files',
+    'upload',
+    '--org',
+    org,
+    '--project',
+    project,
+    // Bundle the referenced native sources so Sentry can show source context in
+    // native stack frames (the analog of the Gradle plugin's
+    // includeNativeSources = true).
+    '--include-sources',
+    ...debugFiles
+  );
+
+  console.info(
+    `[sentry] Uploaded ${debugFiles.length} native debug file(s) for ` +
+      `${platform} to ${org}/${project}.`
+  );
+}
+
+/**
+ * Returns the list of native debug files to upload for the given platform, or
+ * null if symbol upload is not implemented for it.
+ * @param {string} platform
+ * @returns {Promise<string[] | null>}
+ */
+async function collectDebugFiles(platform) {
+  switch (platform) {
+    case 'android':
+      return collectAndroidDebugFiles();
+    default:
+      return null;
+  }
+}
+
+/**
+ * Extracts the unstripped per-ABI .so files from the tun2socks .aar produced by
+ * `go tool task client:tun2socks:android` into a temp directory and returns
+ * their paths. The .aar is the only place the .so exists after gomobile bind;
+ * the Android Gradle Plugin strips the copy it packages into the APK, so the
+ * .so inside this .aar is the unstripped one we want to upload.
+ * @returns {Promise<string[]>}
+ */
+async function collectAndroidDebugFiles() {
+  const aar = path.resolve(
+    getRootDir(),
+    'output/client/android/org/getoutline/client/tun2socks/0.0.1/tun2socks-0.0.1.aar'
+  );
+  try {
+    await fs.access(aar);
+  } catch {
+    throw new Error(
+      `[sentry] Expected tun2socks .aar not found at ${aar}. Build the Android ` +
+        'client (release) before uploading debug symbols.'
+    );
+  }
+
+  const outDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'outline-android-syms-')
+  );
+  // The .aar is a zip; jni/<abi>/libgojni.so holds the native code. Preserve the
+  // jni/<abi>/ layout so same-named .so files across ABIs don't collide.
+  await spawnStream('unzip', '-o', '-q', aar, 'jni/*', '-d', outDir);
+
+  const jniDir = path.join(outDir, 'jni');
+  const files = [];
+  for (const abi of await fs.readdir(jniDir)) {
+    const abiDir = path.join(jniDir, abi);
+    for (const entry of await fs.readdir(abiDir)) {
+      if (entry.endsWith('.so')) {
+        files.push(path.join(abiDir, entry));
+      }
+    }
+  }
+  return files;
+}
+
+/**
+ * Runs `sentry-cli debug-files check` on a file and throws unless it reports
+ * usable debug info that includes DWARF (`debug`) and unwind tables (`unwind`).
+ * This is the guard the task explicitly asked for: uploading a stripped binary
+ * silently produces nothing useful.
+ * @param {string} file
+ * @returns {Promise<void>}
+ */
+async function assertUsableDebugFile(file) {
+  const output = await spawnStream(
+    resolveSentryCli(),
+    'debug-files',
+    'check',
+    file
+  );
+
+  // Parse the feature list from the "Contained debug information:" section
+  // specifically, e.g. "  Contained debug information:\n    > symtab, debug,
+  // unwind". Matching the whole output would falsely pass a DWARF-stripped
+  // binary, because the words "debug" ("Debug ID", "Contained debug
+  // information") appear regardless of whether DWARF is actually present.
+  const featuresMatch = output.match(
+    /Contained debug information:\s*>\s*([^\n]+)/i
+  );
+  const features = (featuresMatch?.[1] ?? '').toLowerCase();
+
+  const usable = /usable:\s*yes/i.test(output);
+  const hasDebug = /\bdebug\b/.test(features);
+  const hasUnwind = /\bunwind\b/.test(features);
+
+  if (!usable || !hasDebug || !hasUnwind) {
+    throw new Error(
+      `[sentry] ${path.basename(file)} is missing usable native debug info ` +
+        `(usable=${usable}, debug=${hasDebug}, unwind=${hasUnwind}). It was ` +
+        "likely stripped at build time (e.g. gomobile -ldflags='-s -w'). " +
+        'Refusing to upload a binary that would symbolicate nothing.\n' +
+        `sentry-cli debug-files check output:\n${output}`
+    );
+  }
+
+  console.info(
+    `[sentry] ${path.basename(file)}: usable native debug info confirmed ` +
+      '(debug + unwind present).'
+  );
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === url.pathToFileURL(process.argv[1]).href
+) {
+  await main(...process.argv.slice(2));
+}

--- a/client/src/cordova/upload_debug_symbols.action.mjs
+++ b/client/src/cordova/upload_debug_symbols.action.mjs
@@ -59,7 +59,7 @@ function resolveSentryCli() {
  * @param {string[]} parameters The list of action arguments passed in.
  */
 export async function main(...parameters) {
-  const {platform, buildMode} = getBuildParameters(parameters);
+  const {platform, buildMode, goArch} = getBuildParameters(parameters);
 
   if (buildMode !== 'release') {
     console.debug(
@@ -68,7 +68,7 @@ export async function main(...parameters) {
     return;
   }
 
-  const debugFiles = await collectDebugFiles(platform);
+  const debugFiles = await collectDebugFiles(platform, goArch);
   if (debugFiles === null) {
     console.warn(
       '[sentry] Native debug symbol upload is not implemented for platform ' +
@@ -86,8 +86,11 @@ export async function main(...parameters) {
   // Verify every file actually carries usable debug info BEFORE uploading. A
   // stripped binary uploads "successfully" but resolves nothing, so we fail the
   // build here rather than ship a symbol pipeline that silently does nothing.
+  // dSYM bundles are directories; check the DWARF binaries inside them.
   for (const file of debugFiles) {
-    await assertUsableDebugFile(file);
+    for (const target of await resolveCheckTargets(file)) {
+      await assertUsableDebugFile(target);
+    }
   }
 
   const org = process.env.SENTRY_ORG || DEFAULT_SENTRY_ORG;
@@ -118,12 +121,19 @@ export async function main(...parameters) {
  * Returns the list of native debug files to upload for the given platform, or
  * null if symbol upload is not implemented for it.
  * @param {string} platform
+ * @param {string | undefined} goArch
  * @returns {Promise<string[] | null>}
  */
-async function collectDebugFiles(platform) {
+async function collectDebugFiles(platform, goArch) {
   switch (platform) {
     case 'android':
       return collectAndroidDebugFiles();
+    case 'linux':
+    case 'windows':
+      return collectElectronDebugFiles(platform, goArch);
+    case 'ios':
+    case 'macos':
+      return collectAppleDebugFiles(platform);
     default:
       return null;
   }
@@ -172,10 +182,111 @@ async function collectAndroidDebugFiles() {
 }
 
 /**
+ * Returns the Go-built native artifacts for a desktop (Electron) build: the
+ * backend shared library and the tun2socks binary, from
+ * output/client/<platform>-<goArch>/. These are shipped unstripped (see the
+ * Taskfile electron task), so the copies on disk carry the DWARF we upload.
+ * @param {string} platform 'linux' | 'windows'
+ * @param {string | undefined} goArch
+ * @returns {Promise<string[]>}
+ */
+async function collectElectronDebugFiles(platform, goArch) {
+  if (!goArch) {
+    throw new Error(
+      `[sentry] --arch is required to locate ${platform} debug files.`
+    );
+  }
+  const binaryDir = path.resolve(
+    getRootDir(),
+    'output',
+    'client',
+    `${platform}-${goArch}`
+  );
+  const candidates =
+    platform === 'windows'
+      ? ['backend.dll', 'tun2socks.exe']
+      : ['libbackend.so', 'tun2socks'];
+
+  const files = [];
+  for (const name of candidates) {
+    const candidate = path.join(binaryDir, name);
+    try {
+      await fs.access(candidate);
+      files.push(candidate);
+    } catch {
+      // The binary for this platform/arch wasn't produced; skip it.
+    }
+  }
+  return files;
+}
+
+/**
+ * Returns the .dSYM bundles for an Apple build. The cordova apple build archives
+ * into Xcode's default Archives folder (the release script locates it there by
+ * timestamp and exports it), so appleRelease's archive path isn't known here.
+ * The caller therefore passes the archive location via SENTRY_DSYMS_PATH —
+ * either the .xcarchive itself or its dSYMs directory. This is invoked from the
+ * release script, which already resolves the archive path.
+ * @param {string} platform 'ios' | 'macos'
+ * @returns {Promise<string[]>}
+ */
+async function collectAppleDebugFiles(platform) {
+  const provided = process.env.SENTRY_DSYMS_PATH;
+  if (!provided) {
+    throw new Error(
+      `[sentry] SENTRY_DSYMS_PATH must point at the ${platform} .xcarchive (or ` +
+        'its dSYMs directory) to upload Apple debug symbols. The release script ' +
+        'sets this after locating the archive.'
+    );
+  }
+  const dsymsDir = provided.endsWith('.xcarchive')
+    ? path.join(provided, 'dSYMs')
+    : provided;
+  try {
+    await fs.access(dsymsDir);
+  } catch {
+    throw new Error(`[sentry] dSYMs directory not found at ${dsymsDir}.`);
+  }
+
+  const files = [];
+  for (const entry of await fs.readdir(dsymsDir)) {
+    if (entry.endsWith('.dSYM')) {
+      files.push(path.join(dsymsDir, entry));
+    }
+  }
+  return files;
+}
+
+/**
+ * Expands a debug-file path into the concrete object files to run
+ * `debug-files check` on. A .dSYM is a bundle directory; its DWARF lives at
+ * Contents/Resources/DWARF/<binary>. Everything else is checked as-is.
+ * @param {string} file
+ * @returns {Promise<string[]>}
+ */
+async function resolveCheckTargets(file) {
+  if (!file.endsWith('.dSYM')) {
+    return [file];
+  }
+  const dwarfDir = path.join(file, 'Contents', 'Resources', 'DWARF');
+  let entries;
+  try {
+    entries = await fs.readdir(dwarfDir);
+  } catch {
+    throw new Error(
+      `[sentry] ${path.basename(file)} has no DWARF payload at ${dwarfDir}; ` +
+        'the archive was likely built without debug information.'
+    );
+  }
+  return entries.map(entry => path.join(dwarfDir, entry));
+}
+
+/**
  * Runs `sentry-cli debug-files check` on a file and throws unless it reports
- * usable debug info that includes DWARF (`debug`) and unwind tables (`unwind`).
- * This is the guard the task explicitly asked for: uploading a stripped binary
- * silently produces nothing useful.
+ * usable debug info that includes DWARF (`debug`). This is the guard the task
+ * explicitly asked for: uploading a stripped binary silently produces nothing
+ * useful. Unwind tables are strongly desired but their presence varies by
+ * object format, so a missing one is a warning rather than a build failure.
  * @param {string} file
  * @returns {Promise<void>}
  */
@@ -201,7 +312,11 @@ async function assertUsableDebugFile(file) {
   const hasDebug = /\bdebug\b/.test(features);
   const hasUnwind = /\bunwind\b/.test(features);
 
-  if (!usable || !hasDebug || !hasUnwind) {
+  // DWARF (`debug`) is the hard requirement: without it a stripped binary
+  // symbolicates nothing, which is exactly what we're guarding against. Unwind
+  // tables are strongly desired but their presence varies by object format, so
+  // a missing one is a warning rather than a build failure.
+  if (!usable || !hasDebug) {
     throw new Error(
       `[sentry] ${path.basename(file)} is missing usable native debug info ` +
         `(usable=${usable}, debug=${hasDebug}, unwind=${hasUnwind}). It was ` +
@@ -211,9 +326,16 @@ async function assertUsableDebugFile(file) {
     );
   }
 
+  if (!hasUnwind) {
+    console.warn(
+      `[sentry] ${path.basename(file)}: DWARF present but no unwind tables ` +
+        'reported; stack unwinding through this frame may be incomplete.'
+    );
+  }
+
   console.info(
     `[sentry] ${path.basename(file)}: usable native debug info confirmed ` +
-      '(debug + unwind present).'
+      `(debug present${hasUnwind ? ', unwind present' : ''}).`
   );
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "client/capacitor"
       ],
       "devDependencies": {
+        "@sentry/cli": "^3.6.2",
         "@storybook/addon-essentials": "^8.2.6",
         "@storybook/addon-links": "^8.2.6",
         "@storybook/blocks": "^8.2.6",
@@ -9809,6 +9810,179 @@
       "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.42.0.tgz",
       "integrity": "sha512-L4rMrXMqUKBanpjpMT+TuAVk6xAijz6AWM6RiEYpohAr7SGcCEc1/T0+Ep1eLV8+pwWacfU27OvELIyNeOnGzA==",
       "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-3.6.2.tgz",
+      "integrity": "sha512-/OcDsuz005C1tuauNhTd8/XNBHCfHiy46Wru4hAKBaziywgSA52lMSEznh6mWmHjPe/FoaDLpYt3Zd9qk3G0RA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "FSL-1.1-MIT",
+      "dependencies": {
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "undici": "^6.22.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "3.6.2",
+        "@sentry/cli-linux-arm": "3.6.2",
+        "@sentry/cli-linux-arm64": "3.6.2",
+        "@sentry/cli-linux-i686": "3.6.2",
+        "@sentry/cli-linux-x64": "3.6.2",
+        "@sentry/cli-win32-arm64": "3.6.2",
+        "@sentry/cli-win32-i686": "3.6.2",
+        "@sentry/cli-win32-x64": "3.6.2"
+      }
+    },
+    "node_modules/@sentry/cli-darwin": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-3.6.2.tgz",
+      "integrity": "sha512-/ZIMLblj6ncwguhOPw5YL9018iaD2RBhxhbHBxjaowy1vrmnzoCurGe4n5Vv7PaS21ldAHtHNqJwNqHJS4XHUw==",
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-3.6.2.tgz",
+      "integrity": "sha512-b2M+1ujgf7jHig9r88T2l2HEkg0XR/1Tmo1LCiPg4dsPKtTMC2Rb/f0Mto83//zkVijAA2WDBhznOz9a9Ouo7Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm64": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-3.6.2.tgz",
+      "integrity": "sha512-KMHW+CIT5H046I1hIYJ6vZmwlbBELZDOTt9Bgue3kqpW5CuvviMeMuuIKXM2oKHr/l4Q1Xnj07oTbVNb1opTsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-linux-i686": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-3.6.2.tgz",
+      "integrity": "sha512-tsLTOfJBoUkHfcCjUKxb/w1/WGLU00WJUO5zJztgLHKlebrjGAEiKM+8EPexb2hiW4F/P6UXL+4xXPKANk5JXQ==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-linux-x64": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-3.6.2.tgz",
+      "integrity": "sha512-CHwfSJYkPe4w96EovIY/iWfxHnf5gvRYh0BGHCPcQ9knhrgWUJqbHqi3lNfEDZmzCxJ76RqPrnLMW6syoSqXow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-win32-arm64": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-3.6.2.tgz",
+      "integrity": "sha512-lTqOPbLexkKnXmuIK8qszv+trpX8fQiZAJoeClVA1+hOerVyrLP9eU2tUqTm/8YW8G/M+mu3ZxAtDvS3OpHvZw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-win32-i686": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-3.6.2.tgz",
+      "integrity": "sha512-niUPoxN8p7jWrkvC0ekgpcIYEJNb5YxmuXRjUnOJrArwQs+4OPzRM+3e6JIYRXe7RDoUP63j1voYakEncuxioQ==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-win32-x64": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-3.6.2.tgz",
+      "integrity": "sha512-Xg6ieuJr/1Ewtdpm9Kudb029lJxnfs3Ae/fLZNAOnvWOie/V4V/X+tgZ+lETC3lU+7yz7Gb0f25gKnU6sPBKVg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
       "engines": {
         "node": ">=18"
       }
@@ -40776,6 +40950,16 @@
       "integrity": "sha512-Ia0sQNrMPXXkqVFt6w6M1n1oKo3NfKs+mvaV811Jwir7vAk9a6PVV9VPYf6X3BU97QiLEmuW3uXH9u87zDFfdw==",
       "dev": true
     },
+    "node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -51042,6 +51226,82 @@
           "integrity": "sha512-L4rMrXMqUKBanpjpMT+TuAVk6xAijz6AWM6RiEYpohAr7SGcCEc1/T0+Ep1eLV8+pwWacfU27OvELIyNeOnGzA=="
         }
       }
+    },
+    "@sentry/cli": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-3.6.2.tgz",
+      "integrity": "sha512-/OcDsuz005C1tuauNhTd8/XNBHCfHiy46Wru4hAKBaziywgSA52lMSEznh6mWmHjPe/FoaDLpYt3Zd9qk3G0RA==",
+      "dev": true,
+      "requires": {
+        "@sentry/cli-darwin": "3.6.2",
+        "@sentry/cli-linux-arm": "3.6.2",
+        "@sentry/cli-linux-arm64": "3.6.2",
+        "@sentry/cli-linux-i686": "3.6.2",
+        "@sentry/cli-linux-x64": "3.6.2",
+        "@sentry/cli-win32-arm64": "3.6.2",
+        "@sentry/cli-win32-i686": "3.6.2",
+        "@sentry/cli-win32-x64": "3.6.2",
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "undici": "^6.22.0",
+        "which": "^2.0.2"
+      }
+    },
+    "@sentry/cli-darwin": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-3.6.2.tgz",
+      "integrity": "sha512-/ZIMLblj6ncwguhOPw5YL9018iaD2RBhxhbHBxjaowy1vrmnzoCurGe4n5Vv7PaS21ldAHtHNqJwNqHJS4XHUw==",
+      "dev": true,
+      "optional": true
+    },
+    "@sentry/cli-linux-arm": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-3.6.2.tgz",
+      "integrity": "sha512-b2M+1ujgf7jHig9r88T2l2HEkg0XR/1Tmo1LCiPg4dsPKtTMC2Rb/f0Mto83//zkVijAA2WDBhznOz9a9Ouo7Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@sentry/cli-linux-arm64": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-3.6.2.tgz",
+      "integrity": "sha512-KMHW+CIT5H046I1hIYJ6vZmwlbBELZDOTt9Bgue3kqpW5CuvviMeMuuIKXM2oKHr/l4Q1Xnj07oTbVNb1opTsg==",
+      "dev": true,
+      "optional": true
+    },
+    "@sentry/cli-linux-i686": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-3.6.2.tgz",
+      "integrity": "sha512-tsLTOfJBoUkHfcCjUKxb/w1/WGLU00WJUO5zJztgLHKlebrjGAEiKM+8EPexb2hiW4F/P6UXL+4xXPKANk5JXQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@sentry/cli-linux-x64": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-3.6.2.tgz",
+      "integrity": "sha512-CHwfSJYkPe4w96EovIY/iWfxHnf5gvRYh0BGHCPcQ9knhrgWUJqbHqi3lNfEDZmzCxJ76RqPrnLMW6syoSqXow==",
+      "dev": true,
+      "optional": true
+    },
+    "@sentry/cli-win32-arm64": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-3.6.2.tgz",
+      "integrity": "sha512-lTqOPbLexkKnXmuIK8qszv+trpX8fQiZAJoeClVA1+hOerVyrLP9eU2tUqTm/8YW8G/M+mu3ZxAtDvS3OpHvZw==",
+      "dev": true,
+      "optional": true
+    },
+    "@sentry/cli-win32-i686": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-3.6.2.tgz",
+      "integrity": "sha512-niUPoxN8p7jWrkvC0ekgpcIYEJNb5YxmuXRjUnOJrArwQs+4OPzRM+3e6JIYRXe7RDoUP63j1voYakEncuxioQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@sentry/cli-win32-x64": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-3.6.2.tgz",
+      "integrity": "sha512-Xg6ieuJr/1Ewtdpm9Kudb029lJxnfs3Ae/fLZNAOnvWOie/V4V/X+tgZ+lETC3lU+7yz7Gb0f25gKnU6sPBKVg==",
+      "dev": true,
+      "optional": true
     },
     "@sentry/core": {
       "version": "10.47.0",
@@ -73445,6 +73705,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/undertaker-registry/-/undertaker-registry-1.0.1.tgz",
       "integrity": "sha512-UR1khWeAjugW3548EfQmL9Z7pGMlBgXteQpr1IZeZBtnkCJQJIJ1Scj0mb9wQaPvUZ9Q17XqW6TIaPchJkyfqw==",
+      "dev": true
+    },
+    "undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true
     },
     "undici-types": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "client/capacitor"
   ],
   "devDependencies": {
+    "@sentry/cli": "^3.6.2",
     "@storybook/addon-essentials": "^8.2.6",
     "@storybook/addon-links": "^8.2.6",
     "@storybook/blocks": "^8.2.6",


### PR DESCRIPTION
> Part 1 of 2 — apps-repo side of automatic native debug-symbol upload to Sentry. Release wiring: OutlineFoundation/outline-release#7.

## Why

Native crashes (e.g. the lwIP `udp_input` SIGBUS in OUTLINE-CLIENTS-NNN28) arrive in Sentry unsymbolicated, and Project Settings → Debug Files for `outline-clients` is empty. The gomobile/electron Go builds pass `-ldflags='-s -w'`, stripping the symbol table and DWARF at build time — no unstripped binary exists for any uploader to find.

## What this does

**Taskfile — stop stripping the Go builds:**
- **Android + Apple** gomobile binds: drop `-s -w`, add `-g` to `CGO_CFLAGS` so cgo/C frames (lwIP) get DWARF too, not just Go frames.
- **Electron** (linux/windows): drop `-s -w` (keep `-X` version) for `libbackend.so` / `backend.dll` / `tun2socks`.
- Remove the now-unused `GOMOBILE_BIND_CMD`.

App size is unaffected on Android (the Gradle plugin strips the copy packaged into the APK; the unstripped copy lives only in the `.aar`). The desktop binaries ship unstripped — negligible next to Electron.

**New `client/src/cordova/upload_debug_symbols` action** — uploads native debug files via `sentry-cli` (`--org outlinevpn --project outline-clients`, `--include-sources`):
- **android:** extracts the per-ABI `.so` from the `.aar`.
- **linux/windows:** uploads the backend library + `tun2socks` from `output/client/<platform>-<goArch>/`.
- **ios/macos:** uploads the `.dSYM` bundles from the Xcode archive, passed in via `SENTRY_DSYMS_PATH`.
- Every file is gated by `sentry-cli debug-files check`: hard-fail unless DWARF is present and `Usable: yes` (a stripped binary can never silently no-op); a missing `unwind` table is only a warning since its presence varies by object format.
- Adds `@sentry/cli` as a devDependency.

## Invocation & auth

The action is not wired into the build — the release pipeline (OutlineFoundation/outline-release#7) invokes it after each platform build, and only for `--buildMode=release`. (Apple must be release-driven: the Xcode archive is located later by the release script, which passes its path in.) `sentry-cli` supplies credentials itself from `sentry-cli login` (`~/.sentryclirc`) or `SENTRY_AUTH_TOKEN`; the action handles no secret.

## Verification

- Synthetic Linux cgo event resolves to file:line (`_cgo_gotypes.go:1046`, `cgo-gcc-prolog:238`): https://outlinevpn.sentry.io/issues/OUTLINE-CLIENTS-NNNJ6

Exercised end-to-end via real `release.sh` candidate builds (v1.21.2-rc.1, internal test builds, never published) for macos
- Real event from the macOS TestFlight build resolves with file:line and source context: https://outlinevpn.sentry.io/issues/OUTLINE-CLIENTS-NNNRJ

- I have not verified e2e crash reporting with symbols for *any build other than macos*. If there are issues on other platforms we'll see them after the next release in the lack of sentry symbols.

## Note

Sentry does not reprocess existing events, and already-shipped builds were stripped at build time — only crashes from builds shipped after this lands will symbolicate.
