### PR TITLE
fix(client): keep Apple + desktop native symbols for Sentry [2/3]

### DIFF
--- a/client/go/Taskfile.yml
+++ b/client/go/Taskfile.yml
@@ -21,9 +21,8 @@ vars:
   OUT_DIR: '{{joinPath .REPO_ROOT "output/client"}}'
   BIN_DIR: '{{joinPath .OUT_DIR "/bin"}}'
   MOBILE_PKG: "{{.TASKFILE_DIR}}/outline/tun2socks"
-  GOMOBILE_BIND_CMD: "env PATH=\"{{.BIN_DIR}}:${PATH}\" CGO_CFLAGS='-fstack-protector-strong' '{{.BIN_DIR}}/gomobile' bind -ldflags='-s -w'"
-  # Android build variant that keeps native debug info so crashes inside
-  # libgojni.so can be symbolicated in Sentry. Differences from the default:
+  # Android gomobile bind that keeps native debug info so crashes inside
+  # libgojni.so can be symbolicated in Sentry. Unlike a stripped build:
   #   - No `-ldflags='-s -w'`: `-s` strips the symbol table, `-w` strips DWARF.
   #     Omitting both leaves symtab + DWARF in the .so, which sentry-cli needs
   #     (a stripped .so uploads but resolves nothing).
@@ -34,6 +33,11 @@ vars:
   # still strips the copy packaged into the shipped APK, so app size is
   # unaffected.
   GOMOBILE_BIND_CMD_ANDROID: "env PATH=\"{{.BIN_DIR}}:${PATH}\" CGO_CFLAGS='-fstack-protector-strong -g' '{{.BIN_DIR}}/gomobile' bind"
+  # Apple build variant, same rationale as GOMOBILE_BIND_CMD_ANDROID: keep the
+  # symbol table + DWARF (no `-s -w`) and add `-g` for the cgo/C frames, so
+  # Xcode's archive step produces dSYMs that resolve native (Go) frames. The
+  # dSYMs are uploaded to Sentry by the upload_debug_symbols action.
+  GOMOBILE_BIND_CMD_APPLE: "env PATH=\"{{.BIN_DIR}}:${PATH}\" CGO_CFLAGS='-fstack-protector-strong -g' '{{.BIN_DIR}}/gomobile' bind"
 
 tasks:
   electron:
@@ -55,17 +59,21 @@ tasks:
       #   Windows: requires 32-bit
       #   Linux: requires older glibc for wider compatibility
       # Linker flags: https://pkg.go.dev/cmd/link
-      #   -s Omit the symbol table and debug information.
-      #   -w Omit the DWARF symbol table.
       #   -X Set the value of the string variable.
+      # We intentionally do NOT pass `-s -w`: `-s` strips the symbol table and
+      # `-w` strips DWARF. Keeping both leaves the debug info that sentry-cli
+      # needs to symbolicate native crashes in the desktop tun2socks binary and
+      # backend library; these files are uploaded to Sentry by the
+      # client/src/cordova/upload_debug_symbols action. The desktop package ships
+      # the unstripped binaries (the size delta is negligible next to Electron).
       - |
         GOOS={{.TARGET_OS}} GOARCH={{.TARGET_ARCH}} CGO_ENABLED=1 \
         CC='zig cc -target {{.ZIG_TARGET}}' \
-        go build -trimpath -ldflags="-s -w -X=main.version={{.TUN2SOCKS_VERSION}}" -o '{{.OUTPUT}}' '{{.TASKFILE_DIR}}/outline/electron'
+        go build -trimpath -ldflags="-X=main.version={{.TUN2SOCKS_VERSION}}" -o '{{.OUTPUT}}' '{{.TASKFILE_DIR}}/outline/electron'
       - |
         GOOS={{.TARGET_OS}} GOARCH={{.TARGET_ARCH}} CGO_ENABLED=1 \
         CC='zig cc -target {{.ZIG_TARGET}}' \
-        go build -trimpath -buildmode=c-shared -ldflags="-s -w -X=main.version={{.TUN2SOCKS_VERSION}}" -o '{{.OUTPUT_LIB}}' '{{.TASKFILE_DIR}}/outline/electron'
+        go build -trimpath -buildmode=c-shared -ldflags="-X=main.version={{.TUN2SOCKS_VERSION}}" -o '{{.OUTPUT_LIB}}' '{{.TASKFILE_DIR}}/outline/electron'
 
   windows:
     deps: [windows:386]
@@ -121,7 +129,7 @@ tasks:
       GODEBUG: gotypesalias=0
     cmds:
       - rm -rf "{{.TARGET_DIR}}" && mkdir -p "{{.TARGET_DIR}}"
-      - export MACOSX_DEPLOYMENT_TARGET={{.MACOSX_DEPLOYMENT_TARGET}}; {{.GOMOBILE_BIND_CMD}} -target=ios,iossimulator,maccatalyst -iosversion={{.TARGET_IOS_VERSION}} -bundleid org.outline.tun2socks -o '{{.TARGET_DIR}}/Tun2socks.xcframework' '{{.TASKFILE_DIR}}/outline/platerrors' '{{.TASKFILE_DIR}}/outline/tun2socks' '{{.TASKFILE_DIR}}/outline'
+      - export MACOSX_DEPLOYMENT_TARGET={{.MACOSX_DEPLOYMENT_TARGET}}; {{.GOMOBILE_BIND_CMD_APPLE}} -target=ios,iossimulator,maccatalyst -iosversion={{.TARGET_IOS_VERSION}} -bundleid org.outline.tun2socks -o '{{.TARGET_DIR}}/Tun2socks.xcframework' '{{.TASKFILE_DIR}}/outline/platerrors' '{{.TASKFILE_DIR}}/outline/tun2socks' '{{.TASKFILE_DIR}}/outline'
     deps: ["gomobile"]
 
   browser:

--- a/client/src/cordova/upload_debug_symbols.action.mjs
+++ b/client/src/cordova/upload_debug_symbols.action.mjs
@@ -59,7 +59,7 @@ function resolveSentryCli() {
  * @param {string[]} parameters The list of action arguments passed in.
  */
 export async function main(...parameters) {
-  const {platform, buildMode} = getBuildParameters(parameters);
+  const {platform, buildMode, goArch} = getBuildParameters(parameters);
 
   if (buildMode !== 'release') {
     console.debug(
@@ -68,7 +68,7 @@ export async function main(...parameters) {
     return;
   }
 
-  const debugFiles = await collectDebugFiles(platform);
+  const debugFiles = await collectDebugFiles(platform, goArch);
   if (debugFiles === null) {
     console.warn(
       '[sentry] Native debug symbol upload is not implemented for platform ' +
@@ -86,8 +86,11 @@ export async function main(...parameters) {
   // Verify every file actually carries usable debug info BEFORE uploading. A
   // stripped binary uploads "successfully" but resolves nothing, so we fail the
   // build here rather than ship a symbol pipeline that silently does nothing.
+  // dSYM bundles are directories; check the DWARF binaries inside them.
   for (const file of debugFiles) {
-    await assertUsableDebugFile(file);
+    for (const target of await resolveCheckTargets(file)) {
+      await assertUsableDebugFile(target);
+    }
   }
 
   const org = process.env.SENTRY_ORG || DEFAULT_SENTRY_ORG;
@@ -118,12 +121,19 @@ export async function main(...parameters) {
  * Returns the list of native debug files to upload for the given platform, or
  * null if symbol upload is not implemented for it.
  * @param {string} platform
+ * @param {string | undefined} goArch
  * @returns {Promise<string[] | null>}
  */
-async function collectDebugFiles(platform) {
+async function collectDebugFiles(platform, goArch) {
   switch (platform) {
     case 'android':
       return collectAndroidDebugFiles();
+    case 'linux':
+    case 'windows':
+      return collectElectronDebugFiles(platform, goArch);
+    case 'ios':
+    case 'macos':
+      return collectAppleDebugFiles(platform);
     default:
       return null;
   }
@@ -172,10 +182,111 @@ async function collectAndroidDebugFiles() {
 }
 
 /**
+ * Returns the Go-built native artifacts for a desktop (Electron) build: the
+ * backend shared library and the tun2socks binary, from
+ * output/client/<platform>-<goArch>/. These are shipped unstripped (see the
+ * Taskfile electron task), so the copies on disk carry the DWARF we upload.
+ * @param {string} platform 'linux' | 'windows'
+ * @param {string | undefined} goArch
+ * @returns {Promise<string[]>}
+ */
+async function collectElectronDebugFiles(platform, goArch) {
+  if (!goArch) {
+    throw new Error(
+      `[sentry] --arch is required to locate ${platform} debug files.`
+    );
+  }
+  const binaryDir = path.resolve(
+    getRootDir(),
+    'output',
+    'client',
+    `${platform}-${goArch}`
+  );
+  const candidates =
+    platform === 'windows'
+      ? ['backend.dll', 'tun2socks.exe']
+      : ['libbackend.so', 'tun2socks'];
+
+  const files = [];
+  for (const name of candidates) {
+    const candidate = path.join(binaryDir, name);
+    try {
+      await fs.access(candidate);
+      files.push(candidate);
+    } catch {
+      // The binary for this platform/arch wasn't produced; skip it.
+    }
+  }
+  return files;
+}
+
+/**
+ * Returns the .dSYM bundles for an Apple build. The cordova apple build archives
+ * into Xcode's default Archives folder (the release script locates it there by
+ * timestamp and exports it), so appleRelease's archive path isn't known here.
+ * The caller therefore passes the archive location via SENTRY_DSYMS_PATH —
+ * either the .xcarchive itself or its dSYMs directory. This is invoked from the
+ * release script, which already resolves the archive path.
+ * @param {string} platform 'ios' | 'macos'
+ * @returns {Promise<string[]>}
+ */
+async function collectAppleDebugFiles(platform) {
+  const provided = process.env.SENTRY_DSYMS_PATH;
+  if (!provided) {
+    throw new Error(
+      `[sentry] SENTRY_DSYMS_PATH must point at the ${platform} .xcarchive (or ` +
+        'its dSYMs directory) to upload Apple debug symbols. The release script ' +
+        'sets this after locating the archive.'
+    );
+  }
+  const dsymsDir = provided.endsWith('.xcarchive')
+    ? path.join(provided, 'dSYMs')
+    : provided;
+  try {
+    await fs.access(dsymsDir);
+  } catch {
+    throw new Error(`[sentry] dSYMs directory not found at ${dsymsDir}.`);
+  }
+
+  const files = [];
+  for (const entry of await fs.readdir(dsymsDir)) {
+    if (entry.endsWith('.dSYM')) {
+      files.push(path.join(dsymsDir, entry));
+    }
+  }
+  return files;
+}
+
+/**
+ * Expands a debug-file path into the concrete object files to run
+ * `debug-files check` on. A .dSYM is a bundle directory; its DWARF lives at
+ * Contents/Resources/DWARF/<binary>. Everything else is checked as-is.
+ * @param {string} file
+ * @returns {Promise<string[]>}
+ */
+async function resolveCheckTargets(file) {
+  if (!file.endsWith('.dSYM')) {
+    return [file];
+  }
+  const dwarfDir = path.join(file, 'Contents', 'Resources', 'DWARF');
+  let entries;
+  try {
+    entries = await fs.readdir(dwarfDir);
+  } catch {
+    throw new Error(
+      `[sentry] ${path.basename(file)} has no DWARF payload at ${dwarfDir}; ` +
+        'the archive was likely built without debug information.'
+    );
+  }
+  return entries.map(entry => path.join(dwarfDir, entry));
+}
+
+/**
  * Runs `sentry-cli debug-files check` on a file and throws unless it reports
- * usable debug info that includes DWARF (`debug`) and unwind tables (`unwind`).
- * This is the guard the task explicitly asked for: uploading a stripped binary
- * silently produces nothing useful.
+ * usable debug info that includes DWARF (`debug`). This is the guard the task
+ * explicitly asked for: uploading a stripped binary silently produces nothing
+ * useful. Unwind tables are strongly desired but their presence varies by
+ * object format, so a missing one is a warning rather than a build failure.
  * @param {string} file
  * @returns {Promise<void>}
  */
@@ -201,7 +312,11 @@ async function assertUsableDebugFile(file) {
   const hasDebug = /\bdebug\b/.test(features);
   const hasUnwind = /\bunwind\b/.test(features);
 
-  if (!usable || !hasDebug || !hasUnwind) {
+  // DWARF (`debug`) is the hard requirement: without it a stripped binary
+  // symbolicates nothing, which is exactly what we're guarding against. Unwind
+  // tables are strongly desired but their presence varies by object format, so
+  // a missing one is a warning rather than a build failure.
+  if (!usable || !hasDebug) {
     throw new Error(
       `[sentry] ${path.basename(file)} is missing usable native debug info ` +
         `(usable=${usable}, debug=${hasDebug}, unwind=${hasUnwind}). It was ` +
@@ -211,9 +326,16 @@ async function assertUsableDebugFile(file) {
     );
   }
 
+  if (!hasUnwind) {
+    console.warn(
+      `[sentry] ${path.basename(file)}: DWARF present but no unwind tables ` +
+        'reported; stack unwinding through this frame may be incomplete.'
+    );
+  }
+
   console.info(
     `[sentry] ${path.basename(file)}: usable native debug info confirmed ` +
-      '(debug + unwind present).'
+      `(debug present${hasUnwind ? ', unwind present' : ''}).`
   );
 }
 


### PR DESCRIPTION
> **Draft — part 2 of 3.** Stacked on #2825. Extends the native debug-symbol pipeline to the remaining native platforms. Release wiring is [outline-release#7](https://github.com/OutlineFoundation/outline-release/pull/7).

## What this does

Builds on #2825's mechanism (un-strip → `debug-files check` gate → `sentry-cli` upload), extending the Taskfile and `collectDebugFiles` to Apple and desktop.

### Taskfile
- **Apple** (`GOMOBILE_BIND_CMD_APPLE`): drop `-s -w`, add `-g`, so `Tun2socks.xcframework` keeps DWARF and Xcode's archive produces dSYMs that resolve native (Go) frames.
- **Electron** (linux/windows): drop `-s -w` (keep `-X` version) so the desktop `tun2socks` binary and backend library (`libbackend.so` / `backend.dll`) keep DWARF. The desktop package ships them unstripped — the size delta is negligible next to Electron.
- Remove the now-unused stripped `GOMOBILE_BIND_CMD`.

### `upload_debug_symbols` action
- **linux/windows:** uploads `libbackend.so`/`backend.dll` + the `tun2socks` binary from `output/client/<platform>-<goArch>/`.
- **ios/macos:** uploads the `.dSYM` bundles from the Xcode archive. The archive lands in Xcode's **default** Archives folder (the release script locates it by timestamp and exports it), so the path is passed in via **`SENTRY_DSYMS_PATH`** — set by the release script (PR 3). dSYM bundles are gated by checking the DWARF binary inside them.
- **Gate relaxed for cross-format use:** DWARF (`debug`) + `Usable: yes` is the hard requirement (what a stripped binary lacks); a missing `unwind` table is now a warning, since its presence varies by object format.

## Verification (done locally)

- **Electron linux:** built `libbackend.so` + `tun2socks` with the new flags → the action gates both (`symtab, debug, unwind` / `Usable: yes`) and proceeds to upload (`sentry-cli` then asks for `sentry-cli login`, as expected).
- **Apple:** built `Tun2socks.xcframework`; `dwarfdump` shows **~143k DWARF entries** (a stripped build has none), confirming the un-strip. The framework is a static `ar` archive, so `sentry-cli` can't check it directly — DWARF flows into the app's **dSYM** at Xcode-archive time, which is why we upload the archive's dSYMs.

## Needs verification in the release environment

- **Apple dSYM end-to-end:** a signed Xcode archive must confirm `Outline.app.dSYM` actually contains the Go/native frames (static-lib DWARF → app dSYM via `dsymutil`). Expected, not locally verifiable.
- **Windows `backend.dll`:** DWARF-in-PE upload not yet run locally (linux ELF proven; PE expected equivalent).