### PR TITLE
refactor(client): enable Electron renderer sandboxing

### DIFF
--- a/client/electron/index.ts
+++ b/client/electron/index.ts
@@ -144,12 +144,7 @@ function setupWindow(): void {
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,
-      // Before Electron 20, renderers that specified a preload script defaulted to being unsandboxed.
-      // This meant that by default, preload scripts had access to Node.js.
-      // Beginning in Electron 20, renderers are sandboxed by default.
-      // https://www.electronjs.org/docs/latest/breaking-changes#default-changed-renderers-without-nodeintegration-true-are-sandboxed-by-default
-      // TODO: Move all Node.js-dependent logic to the main process and enable sandboxing.
-      sandbox: false,
+      sandbox: true,
       preload: path.join(__dirname, 'preload.js'),
     },
   });

--- a/client/electron/preload.ts
+++ b/client/electron/preload.ts
@@ -19,8 +19,6 @@
 
 // Please also update preload.d.ts whenever you changed this file.
 
-import * as os from 'node:os';
-
 import {
   clipboard,
   contextBridge,
@@ -97,7 +95,7 @@ export class ElectronRendererMethodChannel {
 contextBridge.exposeInMainWorld('electron', {
   // TODO: move this os definition to a platform api call in the future
   os: {
-    platform: os.platform(),
+    platform: process.platform,
   },
   // TODO: move this clipboard definition to a platform api call as well
   clipboard: clipboard,


### PR DESCRIPTION
Follow-up to #2739 review comment: Move away from importing Node.js modules (`node:os`) in `client/electron/preload.ts` by using Electron's polyfilled `process.platform` in the preload script, allowing us to enable `sandbox: true` in `client/electron/index.ts`.