### PR TITLE
fix(client): disable GPU acceleration on Linux

### DIFF
--- a/client/electron/index.ts
+++ b/client/electron/index.ts
@@ -59,6 +59,13 @@ const debugMode = process.env.OUTLINE_DEBUG === 'true';
 const IS_LINUX = os.platform() === 'linux';
 const IS_WINDOWS = os.platform() === 'win32';
 
+if (IS_LINUX) {
+  // GPU rendering freezes the UI on some Linux systems (buttons never paint on
+  // the first-run screen): https://github.com/OutlineFoundation/outline-apps/issues/2794
+  // Must be set before the app's "ready" event.
+  app.commandLine.appendSwitch('disable-gpu');
+}
+
 // Used for the auto-connect feature. There will be a tunnel in store
 // if the user was connected at shutdown.
 const tunnelStore = new TunnelStore(app.getPath('userData'));


### PR DESCRIPTION
Fixes #2794

GPU rendering freezes the UI on some Linux systems (possibly an issue with the latest linux electron?) the action buttons on the first-run privacy screen never paint, leaving the app unusable (reported on Ubuntu 26.04). The reporter confirmed launching with `--disable-gpu` works around it.

I also saw gpu painting issues myself when getting arm64 working on linux and can confirm `--disable-gpu` fixes it. However I have not built and tested this specific change on a linux machine.

This bakes that switch into the Electron main process so it always applies on Linux, before the app's `ready` event (required for Chromium command-line switches to take effect). Other platforms are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)