### PR TITLE
fix(client/android): ship Capacitor app under the Cordova package id (localStorage migration)

### DIFF
--- a/client/capacitor/android/app/build.gradle
+++ b/client/capacitor/android/app/build.gradle
@@ -19,7 +19,14 @@ android {
     compileSdk 36
     
     defaultConfig {
-        applicationId "org.outline.client"
+        // Ship under the same package id as the existing Cordova client so the
+        // Play Store delivers this as an in-place update. That is a hard
+        // requirement for the Cordova->Capacitor localStorage migration: the new
+        // app can only read the legacy file:// storage if it inherits the old
+        // app's data directory, which only happens on a same-id upgrade.
+        // (namespace stays org.outline.client — that is the code package, not the
+        // install identity.)
+        applicationId "org.outline.android.client"
         minSdk rootProject.ext.minSdkVersion
         targetSdk 36
         versionCode 1


### PR DESCRIPTION
## Problem

The migration in #2834 reads the legacy Cordova `file://` storage from the app's own data dir. Android only shares that dir when the new app is an **in-place update** of the old one — same `applicationId`.

The Capacitor build uses `applicationId "org.outline.client"` (dev id, installs side-by-side), while the Cordova app is `org.outline.android.client`. So a released build is a **separate app**: it never sees the old data, and **every upgrading user lands in an empty server list.**

## Fix

`applicationId` → `org.outline.android.client` (Cordova production id). `namespace` stays `org.outline.client`.

## Test (Pixel API 36, both debug builds, same debug key)

Cordova (from `master`) with two servers → upgraded in place with the Capacitor build (from #2834):

| Capacitor `applicationId` | Result |
|---|---|
| `org.outline.client` (before) | ❌ empty server list |
| `org.outline.android.client` (this fix) | ✅ both servers migrated (`QA` + `Dynamic Key JSON`) |

## Note for reviewers

This also makes **debug** builds use the production id (no more side-by-side dev install). A `buildTypes` split (release = prod id, debug = dev id) would keep both — happy to switch if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)