### PR TITLE
fix(client): handle unnamed access keys and asynchronous config errors

### DIFF
--- a/client/web/app/outline_server_repository/config.ts
+++ b/client/web/app/outline_server_repository/config.ts
@@ -147,10 +147,9 @@ export async function parseAccessKey(
 function serviceNameFromAccessKey(accessKey: URL): string | undefined {
   if (!accessKey.hash) return;
 
-  return decodeURIComponent(
-    accessKey.hash
-      .slice(1)
-      .split('&')
-      .find(keyValuePair => !keyValuePair.includes('='))
-  );
+  const name = accessKey.hash
+    .slice(1)
+    .split('&')
+    .find(keyValuePair => !keyValuePair.includes('='));
+  return name === undefined ? undefined : decodeURIComponent(name);
 }

--- a/client/web/app/outline_server_repository/server.ts
+++ b/client/web/app/outline_server_repository/server.ts
@@ -172,7 +172,7 @@ async function fetchTunnelConfig(
     );
   }
   try {
-    return parseTunnelConfig(responseBody);
+    return await parseTunnelConfig(responseBody);
   } catch (cause) {
     if (cause instanceof errors.SessionProviderError) {
       throw cause;


### PR DESCRIPTION
## Why

Access keys with only fragment parameters can acquire the literal name `undefined`. Rejections from asynchronous tunnel-config parsing also escape the intended error normalization.

## Changes

- Leave the service name unset when the fragment has no name component; continue decoding actual names.
- Await `parseTunnelConfig` inside its existing try/catch, normalizing asynchronous failures while preserving `SessionProviderError`.

## Verification

- After splitting, all three existing configuration specs passed again on this isolated branch.

- Three existing configuration specs passed using an isolated TypeScript/Jasmine runner.
- Controlled source checks covered parameter-only and named fragments, normalized parse rejections, and preservation of session-provider errors.
- Patch isolation and `git diff --check` passed. Recombining all focused patches reproduces the reviewed source changes exactly.
- No test/spec files were added or modified; controlled probe drivers are kept outside the repository.

## Compatibility and remaining validation

- No access-key format or successful configuration behavior is intentionally changed.
- Full browser/client build checks remain outstanding.

Full npm installation/build checks remain incomplete: npm 12 rejected existing lockfile Git dependencies (`EALLOWGIT`). Isolated registry-only tooling was used without disabling that safeguard.

## Scope

This is one focused part of the reliability review, based directly on upstream `master`; it does not include the other review patches. No installed client, live VPN/DNS setting, or production service was changed by this patch.

## Second review — 2026-08-27

Re-reviewed config parsing, unnamed keys, asynchronous error conversion, and callers. No additional change was justified.

All three existing client configuration specs and targeted TypeScript semantic checks passed; the patch also integrates cleanly with the other client PRs.

All touched files and nearby callers were reviewed again. Each focused patch was also checked in combination with the other seven patches for this repository. External probe drivers remain outside the repositories; no test/spec files were added or modified. Existing full-build and platform-validation limitations above still apply.
