### PR TITLE
fix(manager): clean up health timers and cache unsupported metrics

### DIFF
--- a/server_manager/www/shadowbox_server.ts
+++ b/server_manager/www/shadowbox_server.ts
@@ -314,21 +314,21 @@ export class ShadowboxServer implements server.Server {
 
   isHealthy(timeoutMs = 30000): Promise<boolean> {
     return new Promise<boolean>((fulfill, _reject) => {
+      // Return not healthy if API doesn't complete within timeoutMs.
+      const timeout = setTimeout(() => fulfill(false), timeoutMs);
       // Query the API and expect a successful response to validate that the
       // service is up and running.
       this.getServerConfig().then(
         serverConfig => {
+          clearTimeout(timeout);
           this.serverConfig = serverConfig;
           fulfill(true);
         },
         _e => {
+          clearTimeout(timeout);
           fulfill(false);
         }
       );
-      // Return not healthy if API doesn't complete within timeoutMs.
-      setTimeout(() => {
-        fulfill(false);
-      }, timeoutMs);
     });
   }
 
@@ -399,6 +399,7 @@ export class ShadowboxServer implements server.Server {
       if (error.response?.status !== 404) {
         return false;
       }
+      return (this._supportedExperimentalUniversalMetricsEndpointCache = false);
     }
   }
 

--- a/server_manager/www/shadowbox_server.ts
+++ b/server_manager/www/shadowbox_server.ts
@@ -111,8 +111,7 @@ function makeAccessKeyModel(apiAccessKey: AccessKeyJson): server.AccessKey {
 export class ShadowboxServer implements server.Server {
   private api: PathApiClient;
   private serverConfig: ServerConfigJson;
-  private _supportedExperimentalUniversalMetricsEndpointCache: boolean | null =
-    null;
+  private supportedExperimentalMetrics?: Promise<boolean>;
 
   constructor(private readonly id: string) {}
 
@@ -266,8 +265,9 @@ export class ShadowboxServer implements server.Server {
       accessKeys: [],
     };
 
-    const jsonResponse =
-      await this.api.request<DataUsageByAccessKeyJson>('metrics/transfer');
+    const jsonResponse = await this.api.request<DataUsageByAccessKeyJson>(
+      'metrics/transfer'
+    );
 
     for (const [accessKeyId, bytes] of Object.entries(
       jsonResponse.bytesTransferredByUserId
@@ -312,24 +312,23 @@ export class ShadowboxServer implements server.Server {
     return this.serverConfig.serverId;
   }
 
-  isHealthy(timeoutMs = 30000): Promise<boolean> {
-    return new Promise<boolean>((fulfill, _reject) => {
-      // Return not healthy if API doesn't complete within timeoutMs.
-      const timeout = setTimeout(() => fulfill(false), timeoutMs);
-      // Query the API and expect a successful response to validate that the
-      // service is up and running.
-      this.getServerConfig().then(
-        serverConfig => {
-          clearTimeout(timeout);
-          this.serverConfig = serverConfig;
-          fulfill(true);
-        },
-        _e => {
-          clearTimeout(timeout);
-          fulfill(false);
-        }
-      );
-    });
+  async isHealthy(timeoutMs = 30000): Promise<boolean> {
+    let timeout: ReturnType<typeof setTimeout>;
+    try {
+      const config = await Promise.race([
+        this.getServerConfig(),
+        new Promise<undefined>(resolve => {
+          timeout = setTimeout(() => resolve(undefined), timeoutMs);
+        }),
+      ]);
+      if (!config) return false;
+      this.serverConfig = config;
+      return true;
+    } catch {
+      return false;
+    } finally {
+      clearTimeout(timeout);
+    }
   }
 
   getCreatedDate(): Date {
@@ -338,7 +337,6 @@ export class ShadowboxServer implements server.Server {
 
   async setHostnameForAccessKeys(hostname: string): Promise<void> {
     console.info(`setHostname ${hostname}`);
-    this.serverConfig.hostnameForAccessKeys = hostname;
     await this.api.requestJson<void>('server/hostname-for-access-keys', 'PUT', {
       hostname,
     });
@@ -380,35 +378,38 @@ export class ShadowboxServer implements server.Server {
     return await this.api.request<ServerConfigJson>('server');
   }
 
-  private async getSupportedExperimentalUniversalMetricsEndpoint(): Promise<boolean> {
-    if (this._supportedExperimentalUniversalMetricsEndpointCache !== null) {
-      return this._supportedExperimentalUniversalMetricsEndpointCache;
-    }
-
+  private getSupportedExperimentalUniversalMetricsEndpoint(): Promise<boolean> {
     if (!this.api) {
-      return false;
+      return Promise.resolve(false);
     }
-
-    try {
-      await this.api.request<MetricsJson>(
-        'experimental/server/metrics?since=30d'
-      );
-      return (this._supportedExperimentalUniversalMetricsEndpointCache = true);
-    } catch (error) {
-      // endpoint is not defined, keep set to false
-      if (error.response?.status !== 404) {
-        return false;
-      }
-      return (this._supportedExperimentalUniversalMetricsEndpointCache = false);
+    if (!this.supportedExperimentalMetrics) {
+      const pending = this.api
+        .request<MetricsJson>('experimental/server/metrics?since=30d')
+        .then(
+          () => true,
+          error => {
+            // Cache definite absence, but retry transient failures. An older
+            // API's response must not clear a newer capability request.
+            if (
+              error?.response?.status !== 404 &&
+              this.supportedExperimentalMetrics === pending
+            ) {
+              this.supportedExperimentalMetrics = undefined;
+            }
+            return false;
+          }
+        );
+      this.supportedExperimentalMetrics = pending;
     }
+    return this.supportedExperimentalMetrics;
   }
 
   protected setManagementApi(api: PathApiClient): void {
     this.api = api;
 
     // re-populate the supported endpoint cache
-    this._supportedExperimentalUniversalMetricsEndpointCache = null;
-    this.getSupportedExperimentalUniversalMetricsEndpoint();
+    this.supportedExperimentalMetrics = undefined;
+    void this.getSupportedExperimentalUniversalMetricsEndpoint();
   }
 
   getManagementApiUrl(): string {


### PR DESCRIPTION
## Why

Completed health checks leave their timeout handles alive until the deadline. A definite 404 from the experimental metrics endpoint is not cached, causing repeated unsupported-capability probes.

## Changes

- Race the health request against a deadline, clear its timer on settlement, and ignore responses arriving after the deadline.
- Cache a definite 404 as unsupported; keep other errors retryable.

## Verification

- Controlled actual-source checks passed for health-check timer cleanup after success and failure, and one capability request across two reads of an unsupported endpoint.
- Patch isolation and `git diff --check` passed. Recombining all focused patches reproduces the reviewed source changes exactly.
- No test/spec files were added or modified; controlled probe drivers are kept outside the repository.

## Compatibility and remaining validation

- The health deadline still resolves false rather than aborting the underlying request.
- Full Manager integration checks remain outstanding.

Full npm installation/build checks remain incomplete: npm 12 rejected existing lockfile Git dependencies (`EALLOWGIT`). Isolated registry-only tooling was used without disabling that safeguard.

## Scope

This is one focused part of the reliability review, based directly on upstream `master`; it does not include the other review patches. No installed client, live VPN/DNS setting, or production service was changed by this patch.

## Second review — 2026-08-27

Cache the in-flight capability promise as well as its result. Prevent an old API failure from evicting a newer probe; retry transient failures. Health requests that finish after their deadline no longer overwrite cached configuration. Failed hostname updates retain the previous local value.

Reproduced three capability requests for concurrent readers and the premature hostname mutation before fixing them. Probes now pass for coalescing, stale API ownership, retries, deadline/late-response isolation, and hostname rollback. Targeted TypeScript semantic checks passed.

All touched files and nearby callers were reviewed again. Each focused patch was also checked in combination with the other seven patches for this repository. External probe drivers remain outside the repositories; no test/spec files were added or modified. Existing full-build and platform-validation limitations above still apply.
