### PR TITLE
fix(manager): accept lossless custom access-key IDs in metrics

### DIFF
--- a/server_manager/www/shadowbox_server.ts
+++ b/server_manager/www/shadowbox_server.ts
@@ -73,7 +73,7 @@ interface MetricsJson {
     }[];
   };
   accessKeys: {
-    accessKeyId: number;
+    accessKeyId: number | string;
     tunnelTime: {
       seconds: number;
     };

--- a/server_manager/www/shadowbox_server.ts
+++ b/server_manager/www/shadowbox_server.ts
@@ -73,7 +73,7 @@ interface MetricsJson {
     }[];
   };
   accessKeys: {
-    accessKeyId: number | string;
+    accessKeyId: string;
     tunnelTime: {
       seconds: number;
     };


### PR DESCRIPTION
## Why

The server supports custom access-key IDs, but the experimental metrics response type only describes numeric IDs. The companion server fix preserves custom IDs as strings.

## Changes

- Allow `number | string` in the experimental metrics response interface.
- Keep the existing runtime normalization to strings and compatibility with numeric responses.

## Verification

- Reviewed the existing Manager mapping, which already normalizes IDs with `toString()`; this patch changes only the input type.
- Patch isolation and `git diff --check` passed. Recombining all focused patches reproduces the reviewed source changes exactly.
- No test/spec files were added or modified; controlled probe drivers are kept outside the repository.

## Compatibility and remaining validation

- Compatible with old numeric-only responses. See the companion server PR for the producer-side fix; no server deployment is required to merge this type update.
- Full Manager build checks remain outstanding.

Full npm installation/build checks remain incomplete: npm 12 rejected existing lockfile Git dependencies (`EALLOWGIT`). Isolated registry-only tooling was used without disabling that safeguard.

## Scope

This is one focused part of the reliability review, based directly on upstream `master`; it does not include the other review patches. No installed client, live VPN/DNS setting, or production service was changed by this patch.

## Related PR

Companion response-contract update: https://github.com/OutlineFoundation/outline-server/pull/1711

## Second review — 2026-08-27

Re-reviewed the string/number ID contract and the Manager mapping alongside the server ID patch. No additional change was justified.

Targeted TypeScript semantic checks passed independently and with the other app patches. Server-side probes also verified ordinary and prototype-named custom IDs; the server fix remains a separate PR.

All touched files and nearby callers were reviewed again. Each focused patch was also checked in combination with the other seven patches for this repository. External probe drivers remain outside the repositories; no test/spec files were added or modified. Existing full-build and platform-validation limitations above still apply.
