### PR TITLE
fix(client): bound Windows helper waits and serialize reconnects

### DIFF
--- a/client/electron/go_helpers.ts
+++ b/client/electron/go_helpers.ts
@@ -73,7 +73,8 @@ async function checkUDPConnectivityWithArgs(
   const tun2socks = new ChildProcessHelper(pathToEmbeddedTun2socksBinary());
   tun2socks.isDebugModeEnabled = debugMode;
 
-  console.debug('[tun2socks] - checking connectivity ...', args);
+  // The arguments contain the complete access-key configuration.
+  console.debug('[tun2socks] - checking connectivity ...');
   const output = await tun2socks.launch(args);
 
   // Only parse the first line, because sometimes Windows Crypto API adds warnings to stdout.

--- a/client/electron/go_vpn_tunnel.ts
+++ b/client/electron/go_vpn_tunnel.ts
@@ -223,19 +223,23 @@ export class GoVpnTunnel implements VpnTunnel {
   private updateUdpAndRestartTun2socks(): Promise<void> {
     this.restartRequested = true;
     if (!this.restarting) {
-      this.restarting = this.restartTun2socks().finally(() => {
-        this.restarting = undefined;
-      });
+      this.restarting = this.restartTun2socks();
     }
     return this.restarting;
   }
 
   private async restartTun2socks() {
-    // A network notification can arrive while the initial connection is starting.
-    await this.connecting;
-    while (this.restartRequested && !this.disconnected && !this.suspended) {
-      this.restartRequested = false;
-      await this.checkUdpAndRestartTun2socks();
+    try {
+      // A network notification can arrive while the initial connection is starting.
+      await this.connecting;
+      while (this.restartRequested && !this.disconnected && !this.suspended) {
+        this.restartRequested = false;
+        await this.checkUdpAndRestartTun2socks();
+      }
+    } finally {
+      // Clear ownership before settling the worker promise. A request arriving
+      // in a later microtask must not join a worker that has already finished.
+      this.restarting = undefined;
     }
   }
 

--- a/client/electron/go_vpn_tunnel.ts
+++ b/client/electron/go_vpn_tunnel.ts
@@ -49,8 +49,21 @@ export class GoVpnTunnel implements VpnTunnel {
   private readonly tun2socks: GoTun2socks;
   private isDebugMode = false;
 
-  // See #resumeListener.
   private disconnected = false;
+  private suspended = false;
+  private connecting?: Promise<void>;
+  private restarting?: Promise<void>;
+  private restartRequested = false;
+  private readonly onSuspend = () => {
+    void this.suspendListener().catch(e => {
+      console.error('could not suspend tun2socks:', e);
+    });
+  };
+  private readonly onResume = () => {
+    void this.resumeListener().catch(e => {
+      console.error('could not resume tun2socks:', e);
+    });
+  };
 
   private isUdpEnabled = false;
   private gatewayAdapterIndex?: string;
@@ -90,11 +103,24 @@ export class GoVpnTunnel implements VpnTunnel {
 
   // Fulfills once all three helpers have started successfully.
   async connect(checkProxyConnectivity: boolean) {
+    if (this.disconnected) {
+      throw new Error('tunnel is disconnected');
+    }
+    this.connecting = this.connectInternal(checkProxyConnectivity);
+    try {
+      await this.connecting;
+    } catch (e) {
+      await this.disconnect();
+      throw e;
+    }
+  }
+
+  private async connectInternal(checkProxyConnectivity: boolean) {
     if (IS_WINDOWS) {
       // Windows: when the system suspends, tun2socks terminates due to the TAP device getting
       // closed.
-      powerMonitor.on('suspend', this.suspendListener.bind(this));
-      powerMonitor.on('resume', this.resumeListener.bind(this));
+      powerMonitor.on('suspend', this.onSuspend);
+      powerMonitor.on('resume', this.onResume);
     }
 
     // Disconnect the tunnel if the routing service disconnects unexpectedly.
@@ -122,23 +148,38 @@ export class GoVpnTunnel implements VpnTunnel {
     }
     console.log(`UDP support: ${this.isUdpEnabled}`);
 
+    this.ensureConnected();
     console.log('starting routing daemon');
     this.gatewayAdapterIndex = await this.routing.start();
+    this.ensureConnected();
     await this.startTun2socks();
+    this.ensureConnected();
+  }
+
+  private ensureConnected() {
+    if (this.disconnected) {
+      throw new Error('tunnel is disconnected');
+    }
   }
 
   networkChanged(status: TunnelStatus, gatewayIndex?: string) {
+    if (this.disconnected) {
+      return;
+    }
     if (status === TunnelStatus.CONNECTED) {
       if (gatewayIndex) {
         this.gatewayAdapterIndex = gatewayIndex;
       }
-      if (this.reconnectedListener) {
-        this.reconnectedListener();
-      }
-
-      // Test whether UDP availability has changed; since it won't change 99% of the time, do this
-      // *after* we've informed the client we've reconnected.
-      void this.updateUdpAndRestartTun2socks();
+      this.reconnectingListener?.();
+      void this.updateUdpAndRestartTun2socks()
+        .then(() => {
+          if (!this.disconnected && !this.suspended) {
+            this.reconnectedListener?.();
+          }
+        })
+        .catch(e => {
+          console.error('could not restart tun2socks after network change:', e);
+        });
     } else if (status === TunnelStatus.RECONNECTING) {
       if (this.reconnectingListener) {
         this.reconnectingListener();
@@ -151,6 +192,7 @@ export class GoVpnTunnel implements VpnTunnel {
   }
 
   private async suspendListener() {
+    this.suspended = true;
     // Preemptively stop tun2socks to avoid a silent restart that will fail.
     await this.tun2socks.stop();
     console.log('stopped tun2socks in preparation for suspend');
@@ -158,12 +200,9 @@ export class GoVpnTunnel implements VpnTunnel {
 
   private async resumeListener() {
     if (this.disconnected) {
-      // NOTE: Cannot remove resume listeners - Electron bug?
-      console.error(
-        'resume event invoked but this tunnel is terminated - doing nothing'
-      );
       return;
     }
+    this.suspended = false;
 
     console.log('restarting tun2socks after resume');
     await this.updateUdpAndRestartTun2socks();
@@ -181,7 +220,26 @@ export class GoVpnTunnel implements VpnTunnel {
     }
   }
 
-  private async updateUdpAndRestartTun2socks() {
+  private updateUdpAndRestartTun2socks(): Promise<void> {
+    this.restartRequested = true;
+    if (!this.restarting) {
+      this.restarting = this.restartTun2socks().finally(() => {
+        this.restarting = undefined;
+      });
+    }
+    return this.restarting;
+  }
+
+  private async restartTun2socks() {
+    // A network notification can arrive while the initial connection is starting.
+    await this.connecting;
+    while (this.restartRequested && !this.disconnected && !this.suspended) {
+      this.restartRequested = false;
+      await this.checkUdpAndRestartTun2socks();
+    }
+  }
+
+  private async checkUdpAndRestartTun2socks() {
     try {
       if (IS_WINDOWS) {
         this.isUdpEnabled = await checkUDPConnectivityWindows(
@@ -200,24 +258,31 @@ export class GoVpnTunnel implements VpnTunnel {
       console.error('connectivity check failed:', e);
     }
 
+    if (this.disconnected || this.suspended) {
+      return;
+    }
     // Restart tun2socks.
     try {
       await this.tun2socks.stop();
     } catch {
       // Ignore the errors
     }
-    await this.startTun2socks();
+    if (!this.disconnected && !this.suspended) {
+      await this.startTun2socks();
+    }
   }
 
   // Use #onceDisconnected to be notified when the tunnel terminates.
   async disconnect() {
     if (this.disconnected) {
-      return;
+      return this.onAllHelpersStopped;
     }
+    // Mark this before awaiting anything, so in-flight checks cannot restart it.
+    this.disconnected = true;
 
     if (IS_WINDOWS) {
-      powerMonitor.removeListener('suspend', this.suspendListener.bind(this));
-      powerMonitor.removeListener('resume', this.resumeListener.bind(this));
+      powerMonitor.removeListener('suspend', this.onSuspend);
+      powerMonitor.removeListener('resume', this.onResume);
     }
 
     try {
@@ -236,7 +301,6 @@ export class GoVpnTunnel implements VpnTunnel {
       console.error(`could not stop routing: ${e.message}`);
     }
     this.resolveAllHelpersStopped();
-    this.disconnected = true;
   }
 
   // Fulfills once all helper processes have stopped.
@@ -264,6 +328,7 @@ class GoTun2socks {
   // Resolved when Tun2socks prints "tun2socks running" to stdout
   // Call `monitorStarted` to set this field
   private whenStarted: Promise<void>;
+  private running?: Promise<void>;
   private stopRequested = false;
   private readonly process: ChildProcessHelper;
 
@@ -296,7 +361,7 @@ class GoTun2socks {
     return this.startWithPlatformSpecificArgs(clientConfig, isUdpEnabled, args);
   }
 
-  private startWithPlatformSpecificArgs(
+  private async startWithPlatformSpecificArgs(
     clientConfig: string,
     isUdpEnabled: boolean,
     args: string[]
@@ -319,26 +384,59 @@ class GoTun2socks {
       args.push('-dnsFallback');
     }
 
-    const whenProcessEnded = this.launchWithAutoRestart(args);
+    if (this.running) {
+      return Promise.reject(new Error('tun2socks is already running'));
+    }
+    this.stopRequested = false;
+    const whenProcessEnded = (this.running = this.launchWithAutoRestart(
+      args
+    ).finally(() => {
+      this.running = undefined;
+    }));
 
-    // Either started successfully, or terminated exceptionally
-    return Promise.race([this.whenStarted, whenProcessEnded]);
+    let timeout: NodeJS.Timeout;
+    try {
+      await Promise.race([
+        this.whenStarted,
+        whenProcessEnded,
+        new Promise<void>((_, reject) => {
+          timeout = setTimeout(() => {
+            reject(new Error('tun2socks startup timed out'));
+          }, 30000);
+        }),
+      ]);
+    } catch (e) {
+      try {
+        await this.stop();
+      } catch {
+        // Preserve the startup error rather than the expected termination signal.
+      }
+      throw e;
+    } finally {
+      clearTimeout(timeout);
+    }
   }
 
   private monitorStarted(): Promise<void> {
     return (this.whenStarted = new Promise(resolve => {
+      const readyMessage = 'tun2socks running';
+      let output = '';
       this.process.onStdOut = (data?: string | Buffer) => {
-        if (data?.toString().includes('tun2socks running')) {
+        output += data?.toString() ?? '';
+        if (output.includes(readyMessage)) {
           console.debug('[tun2socks] - started');
           this.process.onStdOut = null;
           resolve();
+        } else {
+          // Preserve only enough text to recognize a marker split across chunks.
+          output = output.slice(-(readyMessage.length - 1));
         }
       };
     }));
   }
 
   private async launchWithAutoRestart(args: string[]): Promise<void> {
-    console.debug('[tun2socks] - starting to route network traffic ...', args);
+    console.debug('[tun2socks] - starting to route network traffic ...');
     let restarting = false;
     let lastError: Error | null = null;
     do {
@@ -357,6 +455,9 @@ class GoTun2socks {
         lastError = null;
         await this.process.launch(args, false);
         console.info('[tun2socks] - exited with no errors');
+        if (!this.stopRequested && !restarting) {
+          lastError = new Error('tun2socks exited before becoming ready');
+        }
       } catch (e) {
         console.error('[tun2socks] - terminated due to:', e);
         lastError = e;
@@ -367,9 +468,15 @@ class GoTun2socks {
     }
   }
 
-  stop() {
+  async stop() {
     this.stopRequested = true;
-    return this.process.stop();
+    const running = this.running;
+    try {
+      await this.process.stop();
+    } finally {
+      // Finish the old restart loop before a new start can reset stopRequested.
+      await running;
+    }
   }
 
   enableDebugMode() {

--- a/client/electron/index.ts
+++ b/client/electron/index.ts
@@ -368,7 +368,8 @@ async function createVpnTunnel(
 
 // Invoked by both the start-proxying event handler and auto-connect.
 async function startVpn(request: StartRequestJson, isAutoConnect: boolean) {
-  console.debug('startVpn called with request ', JSON.stringify(request));
+  // Never log the request: its client field contains access-key credentials.
+  console.debug('startVpn called', request.id);
 
   if (IS_LINUX) {
     await establishVpn(request);

--- a/client/electron/process.ts
+++ b/client/electron/process.ts
@@ -20,7 +20,10 @@ import process from 'node:process';
  * A child process is terminated abnormally, caused by a non-zero exit code.
  */
 export class ProcessTerminatedExitCodeError extends Error {
-  constructor(readonly exitCode: number, errJSON: string) {
+  constructor(
+    readonly exitCode: number,
+    errJSON: string
+  ) {
     super(errJSON);
   }
 }

--- a/client/electron/process.ts
+++ b/client/electron/process.ts
@@ -20,10 +20,7 @@ import process from 'node:process';
  * A child process is terminated abnormally, caused by a non-zero exit code.
  */
 export class ProcessTerminatedExitCodeError extends Error {
-  constructor(
-    readonly exitCode: number,
-    errJSON: string
-  ) {
+  constructor(readonly exitCode: number, errJSON: string) {
     super(errJSON);
   }
 }
@@ -111,7 +108,8 @@ export class ChildProcessHelper {
           // This will be captured by Sentry
           console.error(`[${this.processName} - STDERR]: ${data}`);
         }
-        stdErrJSON += data?.toString() ?? '';
+        // Keep recent diagnostics without retaining a session's entire log.
+        stdErrJSON = (stdErrJSON + (data?.toString() ?? '')).slice(-65536);
       });
 
       if (this.isDebugModeEnabled) {
@@ -139,8 +137,17 @@ export class ChildProcessHelper {
       // Never started.
       return '';
     }
-    this.childProcess.kill();
-    return (await this.waitProcessToExit) ?? '';
+    const childProcess = this.childProcess;
+    const waitProcessToExit = this.waitProcessToExit;
+    childProcess.kill();
+    // A helper stuck during graceful shutdown must not block server switching
+    // forever. Target this process only, even if another one starts meanwhile.
+    const killTimeout = setTimeout(() => childProcess.kill('SIGKILL'), 5000);
+    try {
+      return (await waitProcessToExit) ?? '';
+    } finally {
+      clearTimeout(killTimeout);
+    }
   }
 
   set onStdOut(listener: ((data?: string | Buffer) => void) | null) {

--- a/client/electron/process.ts
+++ b/client/electron/process.ts
@@ -36,10 +36,8 @@ export class ProcessTerminatedSignalError extends Error {
 
 // Simple "one shot" child process launcher.
 //
-// NOTE: Because there is no way in Node.js to tell whether a process launched successfully,
-//       #startInternal always succeeds; use #onExit to be notified when the process has exited
-//       (which may be immediately after calling #startInternal if, e.g. the binary cannot be
-//       found).
+// The launch promise settles on close, after the process and its output streams
+// have finished, including when spawning fails.
 export class ChildProcessHelper {
   private readonly processName: string;
   private childProcess?: ChildProcess;
@@ -73,22 +71,20 @@ export class ChildProcessHelper {
         `subprocess ${this.processName} has already been launched`
       );
     }
-    this.childProcess = spawn(this.path, args);
+    const childProcess = (this.childProcess = spawn(this.path, args));
     return (this.waitProcessToExit = new Promise<string>((resolve, reject) => {
       let stdErrJSON = '';
       let stdOutStr = '';
+      let processError: Error | undefined;
       const onExit = (code?: number, signal?: string) => {
-        if (this.childProcess) {
-          this.childProcess.removeAllListeners();
+        if (this.childProcess === childProcess) {
           this.childProcess = undefined;
-        } else {
-          // When listening to both the 'exit' and 'error' events, guard against accidentally
-          // invoking handler functions multiple times.
-          return;
         }
 
         logExit(this.processName, code, signal);
-        if (code === 0) {
+        if (processError) {
+          reject(processError);
+        } else if (code === 0) {
           resolve(stdOutStr);
         } else if (code) {
           reject(new ProcessTerminatedExitCodeError(code, stdErrJSON));
@@ -119,10 +115,10 @@ export class ChildProcessHelper {
         this.childProcess?.stderr?.pipe(process.stderr);
       }
 
-      // We have to listen for both events: error means the process could not be launched and in that
-      // case exit will not be invoked.
-      this.childProcess?.on('error', onExit.bind(this));
-      this.childProcess?.on('exit', onExit.bind(this));
+      childProcess.on('error', error => {
+        processError = error;
+      });
+      childProcess.once('close', onExit);
     }));
   }
 
@@ -152,9 +148,6 @@ export class ChildProcessHelper {
 
   set onStdOut(listener: ((data?: string | Buffer) => void) | null) {
     this.stdOutListener = listener;
-    if (!this.stdOutListener && !this.isDebugModeEnabled) {
-      this.childProcess?.stdout?.removeAllListeners();
-    }
   }
 }
 

--- a/client/electron/routing_service.ts
+++ b/client/electron/routing_service.ts
@@ -79,7 +79,10 @@ export class RoutingDaemon {
     gatewayIndex?: string
   ) => void;
 
-  constructor(private proxyAddress: string, private isAutoConnect: boolean) {}
+  constructor(
+    private proxyAddress: string,
+    private isAutoConnect: boolean
+  ) {}
 
   // Fulfills once a connection is established with the routing daemon *and* it has successfully
   // configured the system's routing table.

--- a/client/electron/routing_service.ts
+++ b/client/electron/routing_service.ts
@@ -79,67 +79,72 @@ export class RoutingDaemon {
     gatewayIndex?: string
   ) => void;
 
-  constructor(
-    private proxyAddress: string,
-    private isAutoConnect: boolean
-  ) {}
+  constructor(private proxyAddress: string, private isAutoConnect: boolean) {}
 
   // Fulfills once a connection is established with the routing daemon *and* it has successfully
   // configured the system's routing table.
   // Returns a string representing the network adapter index that connects to the gateway.
   async start() {
+    if (this.stopping) {
+      throw new Error('routing daemon has been stopped');
+    }
     return new Promise<string>((fulfill, reject) => {
-      const newSocket = (this.socket = createConnection(SERVICE_NAME, () => {
-        newSocket.removeListener('error', initialErrorHandler);
-        const cleanup = () => {
-          newSocket.removeAllListeners();
-          this.socket = null;
-          this.fulfillDisconnect();
-        };
-        newSocket.once('close', cleanup);
-        newSocket.once('error', cleanup);
+      const socket = (this.socket = createConnection(SERVICE_NAME));
+      const timeout = setTimeout(() => {
+        reject(new Error('routing daemon configuration timed out'));
+        socket.destroy();
+      }, 30000);
 
-        newSocket.once('data', data => {
+      socket.once('close', () => {
+        clearTimeout(timeout);
+        this.socket = null;
+        this.fulfillDisconnect();
+        // Also settle start() if the service closes before its first response.
+        reject(
+          new Error('routing daemon closed before configuration completed')
+        );
+      });
+      socket.once('error', err => {
+        clearTimeout(timeout);
+        const perr = new PlatformError(
+          GoErrorCode.ROUTING_SERVICE_NOT_RUNNING,
+          'routing daemon connection failed',
+          {cause: err}
+        );
+        reject(new Error(perr.toJSON()));
+        socket.destroy();
+      });
+      socket.once('connect', () => {
+        if (this.stopping) {
+          socket.destroy();
+          return;
+        }
+        socket.once('data', data => {
+          clearTimeout(timeout);
           const message = this.parseRoutingServiceResponse(data);
           if (
             !message ||
             message.action !== RoutingServiceAction.CONFIGURE_ROUTING ||
             message.statusCode !== RoutingServiceStatusCode.SUCCESS
           ) {
-            // NOTE: This will rarely occur because the connectivity tests
-            //       performed when the user clicks "CONNECT" should detect when
-            //       the system is offline and that, currently, is pretty much
-            //       the only time the routing service will fail.
             reject(
               new Error(
-                message
-                  ? message.errorMessage
-                  : 'empty routing service response'
+                message?.errorMessage || 'invalid routing service response'
               )
             );
-            newSocket.end();
+            socket.destroy();
             return;
           }
-
-          newSocket.on('data', this.dataHandler.bind(this));
-
-          // Potential race condition: this routing daemon might already be stopped by the tunnel
-          // when one of the dependencies (ss-local/tun2socks) exited
-          // TODO(junyi): better handling this case in the next installation logic fix
+          socket.on('data', this.dataHandler.bind(this));
           if (this.stopping) {
-            cleanup();
-            newSocket.destroy();
-            const perr = new PlatformError(
-              GoErrorCode.ROUTING_SERVICE_NOT_RUNNING,
-              'routing daemon service stopped before started'
+            reject(
+              new Error('routing daemon stopped before configuration completed')
             );
-            reject(new Error(perr.toJSON()));
           } else {
             fulfill(message.gatewayAdapterIndex);
           }
         });
-
-        newSocket.write(
+        socket.write(
           JSON.stringify({
             action: RoutingServiceAction.CONFIGURE_ROUTING,
             parameters: {
@@ -148,19 +153,7 @@ export class RoutingDaemon {
             },
           } as RoutingServiceRequest)
         );
-      }));
-
-      const initialErrorHandler = (err: Error) => {
-        console.error('Routing daemon socket setup failed', err);
-        this.socket = null;
-        const perr = new PlatformError(
-          GoErrorCode.ROUTING_SERVICE_NOT_RUNNING,
-          'routing daemon is not running',
-          {cause: err}
-        );
-        reject(new Error(perr.toJSON()));
-      };
-      newSocket.once('error', initialErrorHandler);
+      });
     });
   }
 
@@ -213,7 +206,11 @@ export class RoutingDaemon {
 
   private async writeReset() {
     return new Promise<void>((resolve, reject) => {
-      const written = this.socket?.write(
+      if (!this.socket) {
+        reject(new Error('routing daemon is disconnected'));
+        return;
+      }
+      this.socket.write(
         JSON.stringify({
           action: RoutingServiceAction.RESET_ROUTING,
           parameters: {},
@@ -226,27 +223,38 @@ export class RoutingDaemon {
           }
         }
       );
-      if (!written) {
-        reject(new Error('Write failed'));
-      }
     });
   }
 
-  // stop() resolves when the stop command has been sent.
-  // Use #onceDisconnected to be notified when the connection terminates.
+  // Wait for the service to release its single-client pipe before another tunnel starts.
   async stop() {
-    if (!this.socket) {
-      // Never started.
+    if (this.stopping) {
+      return this.disconnected;
+    }
+    this.stopping = true;
+    const socket = this.socket;
+    if (!socket) {
       this.fulfillDisconnect();
       return;
     }
-    if (this.stopping) {
-      // Already stopped.
-      return;
+    const timeout = setTimeout(() => {
+      console.warn('routing daemon did not disconnect in time; closing pipe');
+      socket.destroy();
+    }, 10000);
+    try {
+      if (socket.connecting) {
+        socket.destroy();
+      } else {
+        await this.writeReset();
+      }
+      await this.disconnected;
+    } catch (e) {
+      socket.destroy();
+      await this.disconnected;
+      throw e;
+    } finally {
+      clearTimeout(timeout);
     }
-    this.stopping = true;
-
-    return this.writeReset();
   }
 
   get onceDisconnected() {


### PR DESCRIPTION
## Why

Late health checks, overlapping recovery, retained power listeners, and unbounded helper/pipe waits can stall disconnects or restart a tunnel after the user disconnects.

## Changes

- Retain/remove the same sleep/wake callbacks, mark shutdown before asynchronous teardown, and share repeated disconnect waits.
- Serialize/coalesce reconnects; suppress stale checks and recovery during suspension or shutdown.
- Reset helper recovery on each start; handle split readiness output and early clean exit, with a 30-second readiness deadline.
- Wait for routing pipe closure, honor backpressure, and bound configuration/shutdown waits to 30/10 seconds.
- Force-stop helpers that ignore termination after five seconds; cap retained stderr at 65,536 characters and remove configuration-bearing launcher logs.

## Verification

- After splitting, controlled lifecycle/real-child-process checks and the targeted Electron semantic TypeScript check passed again on this isolated branch.

- Actual-source controlled adapters passed repeated connect/disconnect, delayed cancellation, reconnect bursts, suspend/resume, restart-after-crash, split readiness, silent startup, routing close/error/timeout, and backpressure checks.
- Targeted semantic TypeScript checks passed against Electron 30.5.1 declarations.
- A real local child that ignored SIGTERM was killed after about five seconds; the helper could be reused and stderr stayed bounded.
- Patch isolation and `git diff --check` passed. Recombining all focused patches reproduces the reviewed source changes exactly.
- No test/spec files were added or modified; controlled probe drivers are kept outside the repository.

## Compatibility and remaining validation

- Verify deadlines with the Windows routing service and packaged client before release. These bounds do not guarantee a total connect/disconnect duration.
- No live Windows VPN run or long-duration traffic soak was performed. This does not implement protected server handover on Windows.

Full npm installation/build checks remain incomplete: npm 12 rejected existing lockfile Git dependencies (`EALLOWGIT`). Isolated registry-only tooling was used without disabling that safeguard.

## Scope

This is one focused part of the reliability review, based directly on upstream `master`; it does not include the other review patches. No installed client, live VPN/DNS setting, or production service was changed by this patch.

## Second review — 2026-08-27

Clear restart-worker ownership inside its finally block, before its promise settles, so a resume/restart in the following microtask starts a new worker. Settle child helpers on close, preserving the original spawn error and complete output; changing the readiness listener no longer removes the output-draining listener. Simplify stale process comments and callback handling.

Reproduced the finishing-worker lost restart, lost stdout tail, and wrapped ENOENT error. All fixed cases passed, plus 20 connect/disconnect cycles, delayed probes, suspend/resume, startup cancellation/timeouts, routing closure/backpressure, bounded stderr, and real forced shutdown (~5 seconds). Electron/TypeScript semantic checks passed. These controlled probes are not a native Windows routing integration run.

All touched files and nearby callers were reviewed again. Each focused patch was also checked in combination with the other seven patches for this repository. External probe drivers remain outside the repositories; no test/spec files were added or modified. Existing full-build and platform-validation limitations above still apply.

## Security review follow-up — 2026-09-03

- Removed two remaining logs that could serialize complete access-key client configuration into stdout and Sentry breadcrumbs.
- Logging now records only the non-secret request ID or operation name.
- Targeted TypeScript checks, repository formatting, and `git diff --check` pass.
