### PR TITLE
fix(client): isolate VPN cleanup and cancel superseded health checks

### DIFF
--- a/client/go/outline/connectivity/connectivity.go
+++ b/client/go/outline/connectivity/connectivity.go
@@ -23,8 +23,8 @@ import (
 	"net/http"
 	"time"
 
-	"localhost/client/go/outline/platerrors"
 	"golang.getoutline.org/sdk/transport"
+	"localhost/client/go/outline/platerrors"
 )
 
 // TODO: make these values configurable by exposing a struct with the connectivity methods.
@@ -70,7 +70,13 @@ func CheckTCPAndUDPConnectivity(
 
 // CheckTCPConnectivity checks whether the given StreamDialer can relay traffic.
 func CheckTCPConnectivity(sd transport.StreamDialer) error {
-	return CheckTCPConnectivityWithHTTP(tcpTimeout, sd, testTCPURLs)
+	return CheckTCPConnectivityContext(context.Background(), sd)
+}
+
+// CheckTCPConnectivityContext checks TCP connectivity until the check completes,
+// its timeout expires, or ctx is canceled.
+func CheckTCPConnectivityContext(ctx context.Context, sd transport.StreamDialer) error {
+	return checkTCPConnectivityWithHTTP(ctx, tcpTimeout, sd, testTCPURLs)
 }
 
 // CheckUDPConnectivity checks whether the given PacketListener can relay traffic.
@@ -135,6 +141,10 @@ func getDNSRequest() []byte {
 // the URLs in `urlList`, which must use the 'http' scheme.
 // Returns nil on success, error on connectivity failure.
 func CheckTCPConnectivityWithHTTP(timeout time.Duration, dialer transport.StreamDialer, urlList []string) error {
+	return checkTCPConnectivityWithHTTP(context.Background(), timeout, dialer, urlList)
+}
+
+func checkTCPConnectivityWithHTTP(ctx context.Context, timeout time.Duration, dialer transport.StreamDialer, urlList []string) error {
 	if len(urlList) == 0 {
 		return errors.New("test url list is empty")
 	}
@@ -142,8 +152,7 @@ func CheckTCPConnectivityWithHTTP(timeout time.Duration, dialer transport.Stream
 		return context.DeadlineExceeded
 	}
 
-	deadline := time.Now().Add(timeout)
-	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	errCh := make(chan error, len(urlList))
@@ -159,7 +168,13 @@ func CheckTCPConnectivityWithHTTP(timeout time.Duration, dialer transport.Stream
 				endMs := max(int(timeout/time.Millisecond)-500, 0)
 				beginMs := min(endMs, 500)
 				// We use math/rand here because there's no need for strong encryption.
-				time.Sleep(time.Duration(beginMs+rand.Intn(endMs-beginMs+1)) * time.Millisecond)
+				timer := time.NewTimer(time.Duration(beginMs+rand.Intn(endMs-beginMs+1)) * time.Millisecond)
+				defer timer.Stop()
+				select {
+				case <-ctx.Done():
+					return
+				case <-timer.C:
+				}
 			}
 			errCh <- testTCPWithOneURL(ctx, dialer, targetURL)
 		}()
@@ -209,6 +224,10 @@ func testTCPWithOneURL(ctx context.Context, dialer transport.StreamDialer, targe
 		}
 	}
 	defer conn.Close()
+	// A deadline alone does not interrupt reads or writes when the caller cancels
+	// early (or a competing probe succeeds).
+	stopClose := context.AfterFunc(ctx, func() { conn.Close() })
+	defer stopClose()
 	if deadline, ok := ctx.Deadline(); ok {
 		conn.SetDeadline(deadline)
 	}

--- a/client/go/outline/vpn/device.go
+++ b/client/go/outline/vpn/device.go
@@ -21,11 +21,11 @@ import (
 	"log/slog"
 	"sync"
 
-	"localhost/client/go/outline/connectivity"
-	perrs "localhost/client/go/outline/platerrors"
 	"golang.getoutline.org/sdk/network/lwip2transport"
 	"golang.getoutline.org/sdk/network/packetrelay"
 	"golang.getoutline.org/sdk/transport"
+	"localhost/client/go/outline/connectivity"
+	perrs "localhost/client/go/outline/platerrors"
 )
 
 // RemoteDevice is an IO device that connects to a remote Outline server.
@@ -53,7 +53,7 @@ func ConnectRemoteDevice(ctx context.Context, sd transport.StreamDialer, pr pack
 	}
 
 	dev := &RemoteDevice{sd: sd, pr: pr}
-	dev.tcpCheckDone.Go(dev.checkTCPHealthAndUpdate)
+	dev.tcpCheckDone.Go(func() { dev.checkTCPHealthAndUpdate(ctx) })
 	dev.ReadWriteCloser, err = lwip2transport.ConfigureDeviceWithRelay(dev.sd, dev.pr)
 	if err != nil {
 		return nil, errSetupHandler("remote device failed to configure network stack", err)
@@ -78,9 +78,9 @@ func (d *RemoteDevice) GetHealthStatus() error {
 	return d.tcpErr
 }
 
-func (d *RemoteDevice) checkTCPHealthAndUpdate() {
+func (d *RemoteDevice) checkTCPHealthAndUpdate(ctx context.Context) {
 	slog.Debug("remote device is checking TCP health status...")
-	err := connectivity.CheckTCPConnectivity(d.sd)
+	err := connectivity.CheckTCPConnectivityContext(ctx, d.sd)
 
 	d.tcpMu.Lock()
 	defer d.tcpMu.Unlock()

--- a/client/go/outline/vpn/device.go
+++ b/client/go/outline/vpn/device.go
@@ -36,9 +36,9 @@ type RemoteDevice struct {
 	pr packetrelay.PacketRelay
 
 	// health check fields
-	tcpMu        sync.Mutex
 	tcpCheckDone sync.WaitGroup
 	tcpErr       error
+	cancelHealth context.CancelFunc
 }
 
 func ConnectRemoteDevice(ctx context.Context, sd transport.StreamDialer, pr packetrelay.PacketRelay) (_ *RemoteDevice, err error) {
@@ -53,11 +53,12 @@ func ConnectRemoteDevice(ctx context.Context, sd transport.StreamDialer, pr pack
 	}
 
 	dev := &RemoteDevice{sd: sd, pr: pr}
-	dev.tcpCheckDone.Go(func() { dev.checkTCPHealthAndUpdate(ctx) })
 	dev.ReadWriteCloser, err = lwip2transport.ConfigureDeviceWithRelay(dev.sd, dev.pr)
 	if err != nil {
 		return nil, errSetupHandler("remote device failed to configure network stack", err)
 	}
+	ctx, dev.cancelHealth = context.WithCancel(ctx)
+	dev.tcpCheckDone.Go(func() { dev.checkTCPHealthAndUpdate(ctx) })
 	slog.Debug("remote device lwIP network stack configured")
 
 	return dev, nil
@@ -65,6 +66,9 @@ func ConnectRemoteDevice(ctx context.Context, sd transport.StreamDialer, pr pack
 
 // Close closes the connection to the Outline server.
 func (dev *RemoteDevice) Close() (err error) {
+	if dev.cancelHealth != nil {
+		dev.cancelHealth()
+	}
 	if dev.ReadWriteCloser != nil {
 		err = dev.ReadWriteCloser.Close()
 	}
@@ -73,8 +77,7 @@ func (dev *RemoteDevice) Close() (err error) {
 
 func (d *RemoteDevice) GetHealthStatus() error {
 	d.tcpCheckDone.Wait()
-	d.tcpMu.Lock()
-	defer d.tcpMu.Unlock()
+	// The completed wait group publishes the single health-check result.
 	return d.tcpErr
 }
 
@@ -82,8 +85,6 @@ func (d *RemoteDevice) checkTCPHealthAndUpdate(ctx context.Context) {
 	slog.Debug("remote device is checking TCP health status...")
 	err := connectivity.CheckTCPConnectivityContext(ctx, d.sd)
 
-	d.tcpMu.Lock()
-	defer d.tcpMu.Unlock()
 	if d.tcpErr = err; d.tcpErr == nil {
 		slog.Info("remote device TCP is healthy")
 	} else {

--- a/client/go/outline/vpn/vpn.go
+++ b/client/go/outline/vpn/vpn.go
@@ -22,9 +22,9 @@ import (
 	"sync"
 	"time"
 
-	"localhost/client/go/outline/callback"
 	"golang.getoutline.org/sdk/network/packetrelay"
 	"golang.getoutline.org/sdk/transport"
+	"localhost/client/go/outline/callback"
 )
 
 // Config holds the configuration to establish a system-wide [VPNConnection].
@@ -69,6 +69,7 @@ type VPNConnection struct {
 	ID     string           `json:"id"`
 	Status ConnectionStatus `json:"status"`
 
+	statusMu      sync.Mutex
 	cancelEst     context.CancelFunc
 	wgEst, wgCopy sync.WaitGroup
 
@@ -84,8 +85,11 @@ var stateChangeCb callback.Token
 
 // setStatus sets the [VPNConnection] Status and calls the stateChangeCb callback.
 func (c *VPNConnection) setStatus(status ConnectionStatus) {
+	c.statusMu.Lock()
 	c.Status = status
-	if connJson, err := json.Marshal(c); err == nil {
+	connJson, err := json.Marshal(c)
+	c.statusMu.Unlock()
+	if err == nil {
 		callback.DefaultManager().Call(stateChangeCb, string(connJson))
 	} else {
 		slog.Warn("failed to marshal VPN connection", "err", err)
@@ -121,6 +125,7 @@ func EstablishVPN(
 	ctx, c.cancelEst = context.WithCancel(ctx)
 
 	if c.platform, err = newPlatformVPNConn(conf); err != nil {
+		c.cancelEst()
 		return
 	}
 
@@ -128,6 +133,7 @@ func EstablishVPN(
 	defer c.wgEst.Done()
 
 	if err = atomicReplaceVPNConn(c); err != nil {
+		c.cancelEst()
 		c.platform.Close()
 		return
 	}
@@ -187,42 +193,43 @@ func atomicReplaceVPNConn(newConn *VPNConnection) error {
 // closeVPNNoLock closes the current VPN connection stored in conn without acquiring
 // the mutex. It is assumed that the caller holds the mutex.
 func closeVPNNoLock() (err error) {
-	if conn == nil {
+	c := conn
+	if c == nil {
 		return nil
 	}
 
-	slog.Debug("terminating the global vpn connection...", "id", conn.ID)
-	conn.setStatus(ConnectionDisconnecting)
+	slog.Debug("terminating the global vpn connection...", "id", c.ID)
+	c.setStatus(ConnectionDisconnecting)
 	defer func() {
 		if err == nil {
-			slog.Info("vpn connection terminated", "id", conn.ID)
-			conn.setStatus(ConnectionDisconnected)
+			slog.Info("vpn connection terminated", "id", c.ID)
+			c.setStatus(ConnectionDisconnected)
 			conn = nil
 		}
 	}()
 
 	// Cancel the Establish process and wait
-	conn.cancelEst()
-	conn.wgEst.Wait()
+	c.cancelEst()
+	c.wgEst.Wait()
 
 	// This is the only error that matters
-	if conn.platform != nil {
-		err = conn.platform.Close()
+	if c.platform != nil {
+		err = c.platform.Close()
 	}
 
 	// TODO: Implement more sophisticated cancellation
 	// The proxy's Close method might take a long time to return when there are
 	// still outgoing traffic to the proxy in an unreachable network environment.
-	// The conn.wgCopy will also be blocked forever because we are waiting to copy
+	// The c.wgCopy will also be blocked forever because we are waiting to copy
 	// traffic from the proxy to a local tun device.
 	// Therefore we will close the proxy in a goroutine, and wait for wgCopy to be
 	// done with a timeout value.
 
 	// We can ignore the following error
-	if conn.proxy != nil {
+	if c.proxy != nil {
 		go func() {
 			slog.Debug("disconnecting from the remote device ...")
-			if err2 := conn.proxy.Close(); err2 != nil {
+			if err2 := c.proxy.Close(); err2 != nil {
 				slog.Warn("failed to disconnect from the remote device")
 			} else {
 				slog.Info("disconnected from the remote device")
@@ -234,7 +241,7 @@ func closeVPNNoLock() (err error) {
 
 	// Wait for traffic copy go routines to finish
 	go func() {
-		conn.wgCopy.Wait()
+		c.wgCopy.Wait()
 		close(closeDone)
 	}()
 

--- a/client/go/outline/vpn/vpn.go
+++ b/client/go/outline/vpn/vpn.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"golang.getoutline.org/sdk/network/packetrelay"
@@ -81,7 +82,7 @@ type VPNConnection struct {
 // This package allows at most one active VPN connection at the same time.
 var mu sync.Mutex
 var conn *VPNConnection
-var stateChangeCb callback.Token
+var stateChangeCb atomic.Int64
 
 // setStatus sets the [VPNConnection] Status and calls the stateChangeCb callback.
 func (c *VPNConnection) setStatus(status ConnectionStatus) {
@@ -90,7 +91,7 @@ func (c *VPNConnection) setStatus(status ConnectionStatus) {
 	connJson, err := json.Marshal(c)
 	c.statusMu.Unlock()
 	if err == nil {
-		callback.DefaultManager().Call(stateChangeCb, string(connJson))
+		callback.DefaultManager().Call(callback.Token(stateChangeCb.Load()), string(connJson))
 	} else {
 		slog.Warn("failed to marshal VPN connection", "err", err)
 	}
@@ -100,7 +101,7 @@ func (c *VPNConnection) setStatus(status ConnectionStatus) {
 // state change listener.
 // The token should have already been registered with the [callback.DefaultManager].
 func SetStateChangeListener(token callback.Token) {
-	stateChangeCb = token
+	stateChangeCb.Store(int64(token))
 }
 
 // EstablishVPN establishes a new active [VPNConnection] connecting to a [ProxyDevice]


### PR DESCRIPTION
## Why

Asynchronous cleanup dereferences the mutable global connection, allowing old teardown to affect a replacement. Health probes can also outlive cancellation or a successful competing probe.

## Changes

- Capture the connection being closed for asynchronous cleanup and wait groups; serialize status snapshots.
- Release setup contexts on early failures.
- Pass caller cancellation through remote-device TCP health checks, cancel delayed fallback probes, and close blocked probe sockets on cancellation.

## Verification

- After splitting, the relevant existing Go suites passed again with `-race` and targeted `go vet` on this isolated branch; live external connectivity tests were excluded.

- Selected existing connectivity specs passed with `go test -race`; the VPN package compiled (no test files). Targeted `go vet` passed.
- A verification-only overlay reproduced the upstream cleanup race. Patched source passed 1,000 cleanup cycles and concurrent status probes under the race detector.
- A controlled blocked in-memory TCP probe released promptly on cancellation; this is not a VPN switching benchmark.
- Patch isolation and `git diff --check` passed. Recombining all focused patches reproduces the reviewed source changes exactly.
- No test/spec files were added or modified; controlled probe drivers are kept outside the repository.

## Compatibility and remaining validation

- No native Linux NetworkManager or live VPN integration run was performed.
- Does not change the native transport's keepalive policy or provide a cross-platform kill switch.

## Scope

This is one focused part of the reliability review, based directly on upstream `master`; it does not include the other review patches. No installed client, live VPN/DNS setting, or production service was changed by this patch.

## Second review — 2026-08-27

Cancel a device health check when the device closes; start the check only after lwIP setup succeeds. Remove the redundant health-result mutex because the wait group publishes the single result. Store/load the global callback token atomically to avoid listener-registration races.

Existing focused Go suites passed with -race and targeted go vet on this branch and the integrated tree. Actual in-memory lwIP checks confirmed Close cancels a blocked health socket. An external source overlay exercised concurrent status/listener changes and 1,000 cleanup cycles under -race. No native OS tunnel or live VPN was changed.

All touched files and nearby callers were reviewed again. Each focused patch was also checked in combination with the other seven patches for this repository. External probe drivers remain outside the repositories; no test/spec files were added or modified. Existing full-build and platform-validation limitations above still apply.
