### PR TITLE
fix(client): cancel session reports and bound stalled HTTP requests

### DIFF
--- a/client/go/outline/reporting/config.go
+++ b/client/go/outline/reporting/config.go
@@ -27,9 +27,9 @@ import (
 	"strings"
 	"time"
 
-	"localhost/client/go/configyaml"
-	"golang.getoutline.org/sdk/transport"
 	persistentcookiejar "go.nhat.io/cookiejar"
+	"golang.getoutline.org/sdk/transport"
+	"localhost/client/go/configyaml"
 )
 
 type HTTPRequestConfig struct {
@@ -61,6 +61,7 @@ func NewHTTPReporterConfigParser(cookiesFilename string, streamDialer transport.
 		// Create HTTP Client.
 
 		httpClient := &http.Client{
+			Timeout: 30 * time.Second,
 			Transport: &http.Transport{
 				DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 					if strings.HasPrefix(network, "tcp") {

--- a/client/go/outline/reporting/reporter.go
+++ b/client/go/outline/reporting/reporter.go
@@ -37,7 +37,7 @@ type HTTPReporter struct {
 }
 
 func (r *HTTPReporter) Run(sessionCtx context.Context) {
-	r.reportAndLogError()
+	r.reportAndLogError(sessionCtx)
 	if r.Interval == 0 {
 		return
 	}
@@ -52,23 +52,36 @@ func (r *HTTPReporter) Run(sessionCtx context.Context) {
 			if !ok {
 				return
 			}
-			r.reportAndLogError()
+			r.reportAndLogError(sessionCtx)
 		}
 	}
 }
 
-func (r *HTTPReporter) reportAndLogError() {
-	err := r.Report()
-	if err != nil {
+func (r *HTTPReporter) reportAndLogError(ctx context.Context) {
+	err := r.report(ctx)
+	if err != nil && ctx.Err() == nil {
 		slog.Warn("Failed to report", "err", err)
 	}
 }
 
 func (r *HTTPReporter) Report() error {
+	return r.report(context.Background())
+}
+
+func (r *HTTPReporter) report(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	req, err := r.NewRequest()
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
+	// Preserve any request-specific deadline while also honoring session shutdown.
+	requestCtx, cancel := context.WithCancel(req.Context())
+	defer cancel()
+	stopCancel := context.AfterFunc(ctx, cancel)
+	defer stopCancel()
+	req = req.WithContext(requestCtx)
 	req.Close = true
 	req.Header.Add("User-Agent", useragent.GetOutlineUserAgent())
 

--- a/client/go/outline/reporting/reporter.go
+++ b/client/go/outline/reporting/reporter.go
@@ -16,6 +16,7 @@ package reporting
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -48,10 +49,7 @@ func (r *HTTPReporter) Run(sessionCtx context.Context) {
 		select {
 		case <-sessionCtx.Done():
 			return
-		case _, ok := <-ticker.C:
-			if !ok {
-				return
-			}
+		case <-ticker.C:
 			r.reportAndLogError(sessionCtx)
 		}
 	}
@@ -59,7 +57,7 @@ func (r *HTTPReporter) Run(sessionCtx context.Context) {
 
 func (r *HTTPReporter) reportAndLogError(ctx context.Context) {
 	err := r.report(ctx)
-	if err != nil && ctx.Err() == nil {
+	if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, ctx.Err()) {
 		slog.Warn("Failed to report", "err", err)
 	}
 }
@@ -81,6 +79,11 @@ func (r *HTTPReporter) report(ctx context.Context) error {
 	defer cancel()
 	stopCancel := context.AfterFunc(ctx, cancel)
 	defer stopCancel()
+	// AfterFunc runs asynchronously, even when cancellation happened while the
+	// request factory was running. Cancel synchronously before handing it to HTTP.
+	if ctx.Err() != nil {
+		cancel()
+	}
 	req = req.WithContext(requestCtx)
 	req.Close = true
 	req.Header.Add("User-Agent", useragent.GetOutlineUserAgent())


### PR DESCRIPTION
## Why

A stalled session report can survive VPN shutdown and block later periodic reports indefinitely.

## Changes

- Bind in-flight HTTP requests to session cancellation while preserving their request-specific context/deadline.
- Skip reporting for already-canceled sessions and avoid logging cancellation as a report failure.
- Set a 30-second timeout on HTTP clients created by the reporting config parser; preserve the public `Report()` entry point.

## Verification

- After splitting, the relevant existing Go suites passed again with `-race` and targeted `go vet` on this isolated branch; live external connectivity tests were excluded.

- Existing reporting specs passed under `go test -race`; targeted `go vet` passed.
- An actual-source probe against a local stalled HTTP server verified that session cancellation terminates the request and that an already-canceled session creates no request.
- Patch isolation and `git diff --check` passed. Recombining all focused patches reproduces the reviewed source changes exactly.
- No test/spec files were added or modified; controlled probe drivers are kept outside the repository.

## Compatibility and remaining validation

- The 30-second timeout applies to configured reporter clients; custom caller-supplied HTTP clients keep their own timeout settings.
- No deployed reporting backend or long-session soak was exercised.

## Scope

This is one focused part of the reliability review, based directly on upstream `master`; it does not include the other review patches. No installed client, live VPN/DNS setting, or production service was changed by this patch.

## Second review — 2026-08-27

Suppress cancellation errors by error identity instead of dropping every error after session cancellation. Cancel synchronously if cancellation occurred during request construction. Remove an unreachable ticker-channel-closed branch.

Focused Go suites and vet passed. Real local HTTP checks confirmed cancellation closes a stalled report and cancellation during request construction sends no request. An independent request-factory error remains logged when cancellation happens at the same time.

All touched files and nearby callers were reviewed again. Each focused patch was also checked in combination with the other seven patches for this repository. External probe drivers remain outside the repositories; no test/spec files were added or modified. Existing full-build and platform-validation limitations above still apply.
