### PR TITLE
feat(client): retain the Apple VPN interface during server handover

### DIFF
--- a/client/go/outline/tun2socks/device.go
+++ b/client/go/outline/tun2socks/device.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	"localhost/client/go/outline"
+	"localhost/client/go/outline/connectivity"
 	perrs "localhost/client/go/outline/platerrors"
 	"localhost/client/go/outline/vpn"
 )
@@ -43,6 +44,15 @@ type RemoteDevice struct {
 type ConnectRemoteDeviceResult struct {
 	Device *RemoteDevice
 	Error  *perrs.PlatformError
+}
+
+// CheckClientConnectivity validates a replacement client without configuring the
+// singleton lwIP device (which would close the currently connected device).
+func CheckClientConnectivity(client *outline.Client) *perrs.PlatformError {
+	if client == nil {
+		return &perrs.PlatformError{Code: perrs.InternalError, Message: "client must be provided"}
+	}
+	return perrs.ToPlatformError(connectivity.CheckTCPConnectivity(client))
 }
 
 func ConnectRemoteDevice(client *outline.Client) (res *ConnectRemoteDeviceResult) {

--- a/client/src/cordova/apple/OutlineAppleLib/Sources/OutlineTunnel/OutlineVpn.swift
+++ b/client/src/cordova/apple/OutlineAppleLib/Sources/OutlineTunnel/OutlineVpn.swift
@@ -25,6 +25,7 @@ public class OutlineVpn: NSObject {
   public typealias VpnStatusObserver = (NEVPNStatus, String) -> Void
 
   private var vpnStatusObserver: VpnStatusObserver?
+  private let operations = VPNOperationQueue()
 
   private enum Action {
     static let start = "start"
@@ -51,11 +52,28 @@ public class OutlineVpn: NSObject {
 
   /** Starts a VPN tunnel as specified in the OutlineTunnel object. */
   public func start(_ tunnelId: String, named name: String?, withTransport transportConfig: String) async throws {
-    if let manager = await getTunnelManager(), isActiveSession(manager.connection) {
-      DDLogDebug("Stoppping active session before starting new one")
-      await stopSession(manager)
+    try await operations.runStart(tunnelId) { generation in
+      try await self.startSession(tunnelId, named: name, withTransport: transportConfig, generation: generation)
+    }
+  }
+
+  private func startSession(_ tunnelId: String, named name: String?, withTransport transportConfig: String, generation: UInt64) async throws {
+    // An unreadable profile is not proof that no VPN is running.
+    let existingManager = try await NETunnelProviderManager.loadAllFromPreferences().first
+    if let manager = existingManager, isActiveSession(manager.connection) {
+      guard manager.connection.status != .connecting else {
+        throw OutlineError.internalError(message: "VPN is still connecting; retry when it is ready")
+      }
+      // Switching must never use stop/start, including when IPC fails or the
+      // extension is an older version. Keep the existing VPN in that case.
+      try await switchSession(manager, to: tunnelId, named: name ?? "Outline Server", transport: transportConfig, generation: generation)
+      return
+    }
+    if let manager = existingManager, manager.connection.status == .disconnecting {
+      throw OutlineError.internalError(message: "VPN is still disconnecting")
     }
 
+    try await operations.checkGeneration(generation)
     let manager: NETunnelProviderManager
     do {
       manager = try await setupVpn(withId: tunnelId, named: name ?? "Outline Server", withTransport: transportConfig)
@@ -65,49 +83,17 @@ public class OutlineVpn: NSObject {
     }
     let session = manager.connection as! NETunnelProviderSession
 
-    // Register observer for start process completion.
-    class TokenHolder {
-      var token: NSObjectProtocol?
-    }
-    let tokenHolder = TokenHolder()
-      let startDone = Task {
-          await withCheckedContinuation { continuation in
-              tokenHolder.token = NotificationCenter.default.addObserver(forName: .NEVPNStatusDidChange, object: manager.connection, queue: nil) { notification in
-                  // The notification object is always the session, so we can rely on that to not be nil.
-                  guard let connection = notification.object as? NETunnelProviderSession else {
-                      DDLogDebug("Failed to cast notification.object to NETunnelProviderSession")
-                      return
-                  }
-                  
-                  let status = connection.status
-                  DDLogDebug("OutlineVpn.start got status \(String(describing: status)), notification: \(String(describing: notification))")
-                  // The observer may be triggered multiple times, but we only remove it when we reach an end state.
-                  // A successful connection will go through .connecting -> .disconnected
-                  // A failed connection will go through .connecting -> .disconnecting -> .disconnected
-                  // An .invalid event may happen if the configuration is modified and ends in an invalid state.
-                  if status == .connected || status == .disconnected || status == .invalid {
-                      DDLogDebug("Tunnel start done.")
-                      if let token = tokenHolder.token {
-                          NotificationCenter.default.removeObserver(token, name: .NEVPNStatusDidChange, object: connection)
-                      }
-                      continuation.resume()
-                  }
-              }
-          }
-      }
-
-    // Start the session.
     do {
-      DDLogDebug("Calling NETunnelProviderSession.startTunnel([:])")
-      try session.startTunnel(options: [:])
-      DDLogDebug("NETunnelProviderSession.startTunnel() returned")
+      try await operations.checkGeneration(generation)
+      try await waitForVPNStatus(session, terminalStatuses: [.connected, .disconnected, .invalid],
+                                 currentStatuses: [.connected], timeout: 60) {
+        try session.startTunnel(options: [:])
+      }
     } catch {
+      session.stopVPNTunnel()
       DDLogError("Failed to start VPN: \(error.localizedDescription)")
       throw OutlineError.setupSystemVPNFailed(cause: error)
     }
-
-    // Wait for it to be done.
-    await startDone.value
 
     switch manager.connection.status {
     case .connected:
@@ -138,13 +124,23 @@ public class OutlineVpn: NSObject {
 
   /** Tears down the VPN if the tunnel with id |tunnelId| is active. */
   public func stop(_ tunnelId: String) async {
-    guard let manager = await getTunnelManager(),
-          getTunnelId(forManager: manager) == tunnelId,
-          isActiveSession(manager.connection) else {
-      DDLogWarn("Trying to stop tunnel \(tunnelId) that is not running")
-      return
+    // Capture an in-progress switch before awaiting an identity reply: the
+    // runtime may change from A to B while Disconnect(A) is being processed.
+    let cancelledStart = await operations.cancelStarts(for: tunnelId)
+    let wasActive = await isActive(tunnelId)
+    if wasActive { _ = await operations.cancelStarts(for: nil) }
+    try? await operations.run {
+      guard let manager = await getTunnelManager(), isActiveSession(manager.connection) else {
+        return
+      }
+      let session = manager.connection as! NETunnelProviderSession
+      // Runtime identity wins after a handover, even if a preferences write or
+      // its acknowledgement was lost. Fall back for older extensions.
+      let id = (try? await sendSwitchMessage(session, ["action": "getTunnelId.v1"]).id)
+        ?? getTunnelId(forManager: manager)
+      guard id == tunnelId || wasActive || cancelledStart else { return }
+      _ = await stopSession(manager)
     }
-    await stopSession(manager)
   }
 
   /** Calls |observer| when the VPN's status changes. */
@@ -158,15 +154,112 @@ public class OutlineVpn: NSObject {
     guard tunnelId != nil, let manager = await getTunnelManager() else {
       return false
     }
-    return getTunnelId(forManager: manager) == tunnelId && isActiveSession(manager.connection)
+    guard isActiveSession(manager.connection) else { return false }
+    let session = manager.connection as! NETunnelProviderSession
+    let id = (try? await sendSwitchMessage(session, ["action": "getTunnelId.v1"]).id)
+      ?? getTunnelId(forManager: manager)
+    return id == tunnelId
   }
 
   // MARK: - Helpers
 
   public func stopActiveVpn() async {
-    if let manager = await getTunnelManager() {
-      await stopSession(manager)
+    _ = await operations.cancelStarts(for: nil)
+    try? await operations.run {
+      if let manager = await getTunnelManager() {
+        _ = await stopSession(manager)
+      }
     }
+  }
+
+  private func switchSession(_ manager: NETunnelProviderManager, to id: String,
+                             named name: String, transport: String, generation: UInt64) async throws {
+    let session = manager.connection as! NETunnelProviderSession
+    let current = try await sendSwitchMessage(session, ["action": "getTunnelId.v1"])
+    guard let oldId = current.id else {
+      throw OutlineError.internalError(message: "VPN extension did not report its active server")
+    }
+    await operations.addCurrentStartId(oldId)
+    try await operations.checkGeneration(generation)
+    let token = UUID().uuidString
+    let oldConfiguration = manager.protocolConfiguration?.copy() as? NETunnelProviderProtocol
+    // Recover a committed switch whose final preference write was interrupted.
+    if let pending = oldConfiguration?.providerConfiguration?["pendingSwitch"] as? [String: String],
+       let pendingToken = pending["token"], pendingToken == current.token, pending["id"] == oldId,
+       let pendingTransport = pending["transport"] {
+      oldConfiguration?.providerConfiguration = [ConfigKey.tunnelId: oldId, ConfigKey.transport: pendingTransport]
+    }
+    guard oldConfiguration?.providerConfiguration?[ConfigKey.tunnelId] as? String == oldId else {
+      throw OutlineError.internalError(message: "VPN preferences do not match the running server")
+    }
+    let oldName = manager.localizedDescription
+    var preferencesChanged = false
+    var commitSent = false
+    do {
+      let prepared = try await sendSwitchMessage(session, [
+        "action": "prepareSwitch.v1", "token": token, "expectedId": oldId,
+        "id": id, "transport": transport
+      ], timeout: 30)
+      try await operations.checkGeneration(generation)
+      guard prepared.token == token else {
+        throw OutlineError.internalError(message: "VPN extension did not prepare the switch")
+      }
+      guard let configuration = oldConfiguration?.copy() as? NETunnelProviderProtocol else {
+        throw OutlineError.internalError(message: "VPN protocol configuration is missing")
+      }
+      configuration.providerConfiguration?["pendingSwitch"] = [
+        ConfigKey.tunnelId: id, ConfigKey.transport: transport, "token": token
+      ]
+      manager.protocolConfiguration = configuration
+      // Preserve on-demand rules and the existing system tunnel. setupVpn would
+      // reset them and is intentionally only used for a fresh connection.
+      preferencesChanged = true
+      try await manager.saveToPreferences()
+      try await operations.checkGeneration(generation)
+      commitSent = true
+      let committed = try await sendSwitchMessage(session, ["action": "commitSwitch.v1", "token": token])
+      guard committed.id == id && committed.token == token else {
+        throw OutlineError.internalError(message: "VPN extension did not commit the switch")
+      }
+    } catch {
+      _ = try? await sendSwitchMessage(session, ["action": "abortSwitch.v1", "token": token])
+      // A missing reply is not proof of failure: the extension may have switched.
+      // Never roll preferences back without reconciling the runtime identity.
+      let runtime = try? await sendSwitchMessage(session, ["action": "getTunnelId.v1"])
+      if commitSent && runtime?.id == id && runtime?.token == token {
+        await finalizeSwitchPreferences(manager, id: id, name: name, transport: transport)
+        notifySwitched(from: oldId, to: id, status: session.status)
+        return
+      }
+      if preferencesChanged && runtime?.id == oldId {
+        manager.protocolConfiguration = oldConfiguration
+        manager.localizedDescription = oldName
+        do { try await manager.saveToPreferences() }
+        catch { DDLogWarn("Failed to restore VPN preferences after an unsuccessful switch") }
+      }
+      throw error
+    }
+    await finalizeSwitchPreferences(manager, id: id, name: name, transport: transport)
+    notifySwitched(from: oldId, to: id, status: session.status)
+  }
+
+  private func finalizeSwitchPreferences(_ manager: NETunnelProviderManager, id: String,
+                                         name: String, transport: String) async {
+    let configuration = manager.protocolConfiguration as! NETunnelProviderProtocol
+    configuration.providerConfiguration = [ConfigKey.tunnelId: id, ConfigKey.transport: transport]
+    manager.localizedDescription = name
+    do { try await manager.saveToPreferences() }
+    catch {
+      // The persisted pendingSwitch + extension commit marker already select the
+      // new server on restart. This write only compacts that transaction record.
+      DDLogWarn("Failed to compact committed VPN switch preferences")
+    }
+  }
+
+  private func notifySwitched(from oldId: String, to id: String, status: NEVPNStatus) {
+    // These are logical server changes, not system VPN teardown notifications.
+    if oldId != id { vpnStatusObserver?(.disconnected, oldId) }
+    vpnStatusObserver?(status, id)
   }
 
   // Adds a VPN configuration to the user preferences if no Outline profile is present. Otherwise
@@ -217,18 +310,25 @@ public class OutlineVpn: NSObject {
       DDLogDebug("Bad manager in OutlineVpn.vpnStatusChanged session=\(String(describing:session)) status=\(String(describing: session.status))")
       return
     }
-    guard let protoConfig = manager.protocolConfiguration as? NETunnelProviderProtocol,
-          let tunnelId = protoConfig.providerConfiguration?["id"] as? String else {
-      DDLogWarn("Bad VPN Config: \(String(describing: session.manager.protocolConfiguration))")
-      return
-    }
-    DDLogDebug("OutlineVpn received status change for \(tunnelId): \(String(describing: session.status))")
-    if isActiveSession(session) {
-      Task {
-        await setConnectVpnOnDemand(manager, true)
+    let status = session.status
+    Task {
+      try? await operations.run {
+        // An earlier notification must not re-enable on-demand after Disconnect.
+        guard session.status == status else { return }
+        var tunnelId = getTunnelId(forManager: manager)
+        if status == .connected || status == .reasserting {
+          if let runtime = try? await sendSwitchMessage(session, ["action": "getTunnelId.v1"]),
+             let runtimeId = runtime.id {
+            tunnelId = runtimeId
+          }
+        }
+        guard let tunnelId = tunnelId else { return }
+        if isActiveSession(session) {
+          await setConnectVpnOnDemand(manager, true)
+        }
+        self.vpnStatusObserver?(status, tunnelId)
       }
     }
-    self.vpnStatusObserver?(session.status, tunnelId)
   }
 }
 
@@ -257,29 +357,80 @@ private func isActiveSession(_ session: NEVPNConnection?) -> Bool {
   return vpnStatus == .connected || vpnStatus == .connecting || vpnStatus == .reasserting
 }
 
-private func stopSession(_ manager:NETunnelProviderManager) async {
+private func stopSession(_ manager: NETunnelProviderManager) async -> Bool {
   do {
     try await manager.loadFromPreferences()
-    await setConnectVpnOnDemand(manager, false) // Disable on demand so the VPN does not connect automatically.
-    manager.connection.stopVPNTunnel()
-    // Wait for stop to be completed.
-    class TokenHolder {
-      var token: NSObjectProtocol?
+    await setConnectVpnOnDemand(manager, false)
+    try await waitForVPNStatus(manager.connection, terminalStatuses: [.disconnected, .invalid],
+                               currentStatuses: [.disconnected, .invalid], timeout: 15) {
+      manager.connection.stopVPNTunnel()
     }
-    let tokenHolder = TokenHolder()
-    await withCheckedContinuation { continuation in
-      tokenHolder.token = NotificationCenter.default.addObserver(forName: .NEVPNStatusDidChange, object: manager.connection, queue: nil) { notification in
-        if manager.connection.status == .disconnected {
-          DDLogDebug("Tunnel stopped. Ready to start again.")
-          if let token = tokenHolder.token {
-            NotificationCenter.default.removeObserver(token, name: .NEVPNStatusDidChange, object: manager.connection)
-          }
-          continuation.resume()
-        }
+    return true
+  } catch {
+    DDLogWarn("Failed to stop VPN: \(error.localizedDescription)")
+    return false
+  }
+}
+
+// Register synchronously before starting the operation. Notifications, errors and
+// the timeout can race, so the continuation and observer must be finished once.
+private final class VPNStatusWaiter: @unchecked Sendable {
+  private let lock = NSLock()
+  private var continuation: CheckedContinuation<Void, Error>?
+  private var observer: NSObjectProtocol?
+  private var timeoutWork: DispatchWorkItem?
+
+  init(_ continuation: CheckedContinuation<Void, Error>) {
+    self.continuation = continuation
+  }
+
+  func observe(_ connection: NEVPNConnection, statuses: [NEVPNStatus], timeout: TimeInterval) {
+    lock.lock()
+    observer = NotificationCenter.default.addObserver(forName: .NEVPNStatusDidChange,
+                                                       object: connection, queue: nil) { [self] _ in
+      if statuses.contains(connection.status) {
+        finish(.success(()))
       }
     }
-  } catch {
-    DDLogWarn("Failed to stop VPN")
+    let work = DispatchWorkItem { [self] in
+      finish(.failure(OutlineError.internalError(message: "VPN status change timed out")))
+    }
+    timeoutWork = work
+    lock.unlock()
+    DispatchQueue.global().asyncAfter(deadline: .now() + timeout, execute: work)
+  }
+
+  func finish(_ result: Result<Void, Error>) {
+    lock.lock()
+    let continuation = self.continuation
+    self.continuation = nil
+    let observer = self.observer
+    self.observer = nil
+    let timeoutWork = self.timeoutWork
+    self.timeoutWork = nil
+    lock.unlock()
+    if let observer = observer {
+      NotificationCenter.default.removeObserver(observer)
+    }
+    timeoutWork?.cancel()
+    continuation?.resume(with: result)
+  }
+}
+
+private func waitForVPNStatus(_ connection: NEVPNConnection, terminalStatuses: [NEVPNStatus],
+                              currentStatuses: [NEVPNStatus], timeout: TimeInterval,
+                              action: () throws -> Void) async throws {
+  try await withCheckedThrowingContinuation { continuation in
+    let waiter = VPNStatusWaiter(continuation)
+    waiter.observe(connection, statuses: terminalStatuses, timeout: timeout)
+    do {
+      try action()
+      if currentStatuses.contains(connection.status) {
+        waiter.finish(.success(()))
+      }
+    } catch {
+      waiter.finish(.failure(error))
+    }
   }
 }
 
@@ -358,4 +509,110 @@ private func fetchExtensionLastDisconnectErrorViaIPC(_ session: NETunnelProvider
       message: "IPC fetchLastDisconnectError failed: \(error.localizedDescription)"
     )
   }
+}
+
+
+// An actor alone is reentrant across awaits. Chaining tasks serializes complete
+// user operations and preference updates, including rapid clicks on other servers.
+private actor VPNOperationQueue {
+  private var tail: Task<Void, Never>?
+  private var generation: UInt64 = 0
+  private var pendingStarts = [UUID: Set<String>]()
+  private var currentStart: UUID?
+
+  func runStart(_ id: String, operation: @escaping (UInt64) async throws -> Void) async throws {
+    let request = UUID()
+    let generation = self.generation
+    pendingStarts[request] = [id]
+    defer {
+      pendingStarts.removeValue(forKey: request)
+      if currentStart == request { currentStart = nil }
+    }
+    try await run {
+      try self.checkGeneration(generation)
+      self.currentStart = request
+      try await operation(generation)
+    }
+  }
+
+  func addCurrentStartId(_ id: String) {
+    if let currentStart = currentStart { pendingStarts[currentStart]?.insert(id) }
+  }
+
+  func cancelStarts(for id: String?) -> Bool {
+    let matches = id == nil || pendingStarts.values.contains { $0.contains(id!) }
+    if matches { generation &+= 1 }
+    return matches && !pendingStarts.isEmpty
+  }
+
+  func checkGeneration(_ expected: UInt64) throws {
+    guard expected == generation else {
+      throw OutlineError.internalError(message: "VPN connection cancelled by Disconnect")
+    }
+  }
+
+  func run(_ operation: @escaping () async throws -> Void) async throws {
+    let previous = tail
+    let task = Task {
+      await previous?.value
+      try await operation()
+    }
+    tail = Task { _ = try? await task.value }
+    try await task.value
+  }
+}
+
+// Keep aligned with SwiftBridge.switchResponse and the versioned extension IPC.
+private struct SwitchResponse: Decodable {
+  let id: String?
+  let token: String?
+  let errorCode: String?
+  let errorJson: String?
+}
+
+private final class ProviderMessageWaiter: @unchecked Sendable {
+  private let lock = NSLock()
+  private var continuation: CheckedContinuation<Data, Error>?
+
+  init(_ continuation: CheckedContinuation<Data, Error>) {
+    self.continuation = continuation
+  }
+
+  func finish(_ result: Result<Data, Error>) {
+    lock.lock()
+    let continuation = self.continuation
+    self.continuation = nil
+    lock.unlock()
+    continuation?.resume(with: result)
+  }
+}
+
+private func sendSwitchMessage(_ session: NETunnelProviderSession, _ request: [String: String],
+                                timeout: TimeInterval = 5) async throws -> SwitchResponse {
+  let message = try JSONSerialization.data(withJSONObject: request)
+  let data: Data = try await withCheckedThrowingContinuation { continuation in
+    let waiter = ProviderMessageWaiter(continuation)
+    let deadline = DispatchWorkItem {
+      waiter.finish(.failure(OutlineError.internalError(message: "VPN extension message timed out")))
+    }
+    DispatchQueue.global().asyncAfter(deadline: .now() + timeout, execute: deadline)
+    do {
+      try session.sendProviderMessage(message) { data in
+        deadline.cancel()
+        if let data = data {
+          waiter.finish(.success(data))
+        } else {
+          waiter.finish(.failure(OutlineError.internalError(message: "VPN extension does not support protected switching")))
+        }
+      }
+    } catch {
+      deadline.cancel()
+      waiter.finish(.failure(error))
+    }
+  }
+  let response = try JSONDecoder().decode(SwitchResponse.self, from: data)
+  if let code = response.errorCode, let json = response.errorJson {
+    throw OutlineError.detailedJsonError(code: code, json: json)
+  }
+  return response
 }

--- a/client/src/cordova/apple/OutlineAppleLib/Sources/OutlineTunnel/OutlineVpn.swift
+++ b/client/src/cordova/apple/OutlineAppleLib/Sources/OutlineTunnel/OutlineVpn.swift
@@ -27,13 +27,6 @@ public class OutlineVpn: NSObject {
   private var vpnStatusObserver: VpnStatusObserver?
   private let operations = VPNOperationQueue()
 
-  private enum Action {
-    static let start = "start"
-    static let restart = "restart"
-    static let stop = "stop"
-    static let getTunnelId = "getTunnelId"
-  }
-
   private enum ConfigKey {
     static let tunnelId = "id"
     static let transport = "transport"
@@ -452,12 +445,13 @@ private func setConnectVpnOnDemand(_ manager: NETunnelProviderManager?, _ enable
 // Returns nil if the tunnel disconnected cleanly, or an Error describing the failure.
 private func fetchExtensionLastDisconnectError(_ session: NETunnelProviderSession) async -> Error? {
   if #available(macOS 13.0, iOS 16.0, *) {
-    return await withCheckedContinuation { continuation in
-      DDLogDebug("Calling fetchLastDisconnectError")
-      session.fetchLastDisconnectError { error in
-        DDLogDebug("fetchLastDisconnectError returned: \(String(describing: error))")
-        continuation.resume(returning: error)
+    do {
+      let error: Error? = try await withVPNDeadline {
+        finish in session.fetchLastDisconnectError { finish(.success($0)) }
       }
+      return error
+    } catch {
+      return error
     }
   }
   // Fallback for macOS 12 / iOS 15: use IPC to read the error the extension saved to disk.
@@ -479,35 +473,17 @@ private struct LastErrorIPCData: Decodable {
 // TODO: Remove once we only support macOS 13.0+, iOS 16.0+
 private func fetchExtensionLastDisconnectErrorViaIPC(_ session: NETunnelProviderSession) async -> Error? {
   do {
-    guard let rpcNameData = ExtensionIPC.fetchLastDetailedJsonError.data(using: .utf8) else {
-      return OutlineError.internalError(message: "IPC fetchLastDisconnectError failed")
-    }
-    return try await withCheckedThrowingContinuation { continuation in
-      do {
-        DDLogDebug("Calling Extension IPC: \(ExtensionIPC.fetchLastDetailedJsonError)")
-        try session.sendProviderMessage(rpcNameData) { data in
-          guard let response = data else {
-            DDLogDebug("Extension IPC returned with nil error")
-            return continuation.resume(returning: nil)
-          }
-          do {
-            let lastError = try PropertyListDecoder().decode(LastErrorIPCData.self, from: response)
-            DDLogDebug("Extension IPC returned with \(lastError)")
-            continuation.resume(returning: OutlineError.detailedJsonError(code: lastError.errorCode,
-                                                                          json: lastError.errorJson))
-          } catch {
-            continuation.resume(throwing: error)
-          }
-        }
-      } catch {
-        continuation.resume(throwing: error)
+    let response: Data? = try await withVPNDeadline { finish in
+      try session.sendProviderMessage(Data(ExtensionIPC.fetchLastDetailedJsonError.utf8)) {
+        finish(.success($0))
       }
     }
+    guard let response = response else { return nil }
+    let lastError = try PropertyListDecoder().decode(LastErrorIPCData.self, from: response)
+    return OutlineError.detailedJsonError(code: lastError.errorCode, json: lastError.errorJson)
   } catch {
     DDLogError("Failed to invoke VPN Extension IPC: \(error)")
-    return OutlineError.internalError(
-      message: "IPC fetchLastDisconnectError failed: \(error.localizedDescription)"
-    )
+    return OutlineError.internalError(message: "IPC fetchLastDisconnectError failed: \(error.localizedDescription)")
   }
 }
 
@@ -570,15 +546,15 @@ private struct SwitchResponse: Decodable {
   let errorJson: String?
 }
 
-private final class ProviderMessageWaiter: @unchecked Sendable {
+private final class VPNValueWaiter<Value>: @unchecked Sendable {
   private let lock = NSLock()
-  private var continuation: CheckedContinuation<Data, Error>?
+  private var continuation: CheckedContinuation<Value, Error>?
 
-  init(_ continuation: CheckedContinuation<Data, Error>) {
+  init(_ continuation: CheckedContinuation<Value, Error>) {
     self.continuation = continuation
   }
 
-  func finish(_ result: Result<Data, Error>) {
+  func finish(_ result: Result<Value, Error>) {
     lock.lock()
     let continuation = self.continuation
     self.continuation = nil
@@ -587,27 +563,36 @@ private final class ProviderMessageWaiter: @unchecked Sendable {
   }
 }
 
-private func sendSwitchMessage(_ session: NETunnelProviderSession, _ request: [String: String],
-                                timeout: TimeInterval = 5) async throws -> SwitchResponse {
-  let message = try JSONSerialization.data(withJSONObject: request)
-  let data: Data = try await withCheckedThrowingContinuation { continuation in
-    let waiter = ProviderMessageWaiter(continuation)
+private func withVPNDeadline<Value>(timeout: TimeInterval = 5,
+                                     operation: (@escaping (Result<Value, Error>) -> Void) throws -> Void) async throws -> Value {
+  try await withCheckedThrowingContinuation { continuation in
+    let waiter = VPNValueWaiter(continuation)
     let deadline = DispatchWorkItem {
       waiter.finish(.failure(OutlineError.internalError(message: "VPN extension message timed out")))
     }
     DispatchQueue.global().asyncAfter(deadline: .now() + timeout, execute: deadline)
     do {
-      try session.sendProviderMessage(message) { data in
+      try operation { result in
         deadline.cancel()
-        if let data = data {
-          waiter.finish(.success(data))
-        } else {
-          waiter.finish(.failure(OutlineError.internalError(message: "VPN extension does not support protected switching")))
-        }
+        waiter.finish(result)
       }
     } catch {
       deadline.cancel()
       waiter.finish(.failure(error))
+    }
+  }
+}
+
+private func sendSwitchMessage(_ session: NETunnelProviderSession, _ request: [String: String],
+                                timeout: TimeInterval = 5) async throws -> SwitchResponse {
+  let message = try JSONSerialization.data(withJSONObject: request)
+  let data: Data = try await withVPNDeadline(timeout: timeout) { finish in
+    try session.sendProviderMessage(message) { data in
+      if let data = data {
+        finish(.success(data))
+      } else {
+        finish(.failure(OutlineError.internalError(message: "VPN extension does not support protected switching")))
+      }
     }
   }
   let response = try JSONDecoder().decode(SwitchResponse.self, from: data)

--- a/client/src/cordova/apple/OutlineLib/VpnExtension/Sources/PacketTunnelProvider.m
+++ b/client/src/cordova/apple/OutlineLib/VpnExtension/Sources/PacketTunnelProvider.m
@@ -123,11 +123,8 @@ NSString *const kDefaultPathKey = @"defaultPath";
   bool isOnDemand = isOnDemandNumber != nil && [isOnDemandNumber intValue] == 1;
   DDLogDebug(@"isOnDemand is %d", isOnDemand);
 
-  BOOL isRestart = self.remoteDevice != nil;
-  if (isRestart) {
-    [self.remoteDevice close];
-  }
-  DDLogDebug(@"isRestart is %d", isRestart);
+  [self.remoteDevice close];
+  self.remoteDevice = nil;
 
   PlaterrorsPlatformError *deviceErr = [self connectRemoteDevice:isOnDemand];
   if (deviceErr != nil) {
@@ -141,9 +138,11 @@ NSString *const kDefaultPathKey = @"defaultPath";
               return startDone([SwiftBridge newInternalOutlineErrorWithMessage:@"VPN start cancelled"]);
             }
             if (error != nil) {
+              [self.remoteDevice close];
+              self.remoteDevice = nil;
               return startDone([SwiftBridge newOutlineErrorFromNsError:error]);
             }
-            PlaterrorsPlatformError *relayErr = [self relayTraffic:isRestart];
+            PlaterrorsPlatformError *relayErr = [self relayTraffic:NO];
             if (relayErr != nil) {
               return startDone([SwiftBridge newOutlineErrorFromPlatformError:relayErr]);
             }
@@ -183,7 +182,8 @@ NSString *const kDefaultPathKey = @"defaultPath";
     dispatch_async(strongSelf.packetQueue, ^{
       if (!strongSelf.stopping && strongSelf.sessionGeneration == generation && error == nil) {
         DDLogInfo(@"Routing started");
-        strongSelf.reasserting = strongSelf.remoteDevice == nil;
+        strongSelf.reasserting = strongSelf.remoteDevice == nil ||
+            (strongSelf.defaultPath != nil && strongSelf.defaultPath.status != NWPathStatusSatisfied);
       }
       completionHandler(error);
     });
@@ -277,8 +277,12 @@ bool getIpAddressString(const struct sockaddr *sa, char *s, socklen_t maxbytes) 
     return;
   }
   // Nothing changed. Connect the tunnel with the current settings.
+  NSUInteger generation = self.sessionGeneration;
   [self startRouting:[SwiftBridge getTunnelNetworkSettings]
          completion:^(NSError *_Nullable error) {
+           if (self.stopping || self.sessionGeneration != generation) {
+             return;
+           }
            if (error != nil) {
              // A routing refresh failure must not tear down the protected session.
              self.reasserting = YES;
@@ -302,6 +306,7 @@ bool getIpAddressString(const struct sockaddr *sa, char *s, socklen_t maxbytes) 
   if (self.stopping) {
     return;
   }
+  NSUInteger generation = self.sessionGeneration;
   __weak typeof(self) weakSelf = self;
   [self.packetFlow readPacketsWithCompletionHandler:^(NSArray<NSData *> *packets,
                                                       NSArray<NSNumber *> *protocols) {
@@ -310,7 +315,7 @@ bool getIpAddressString(const struct sockaddr *sa, char *s, socklen_t maxbytes) 
       return;
     }
     dispatch_async(strongSelf.packetQueue, ^{
-      if (strongSelf.stopping) {
+      if (strongSelf.stopping || strongSelf.sessionGeneration != generation) {
         return;
       }
       long bytesWritten = 0;
@@ -340,6 +345,7 @@ bool getIpAddressString(const struct sockaddr *sa, char *s, socklen_t maxbytes) 
     if (healthErr != nil) {
       DDLogError(@"Remote device is not healthy: %@", healthErr.error);
       [self.remoteDevice close];
+      self.remoteDevice = nil;
       return healthErr;
     }
     DDLogInfo(@"Remote device is healthy.");

--- a/client/src/cordova/apple/OutlineLib/VpnExtension/Sources/PacketTunnelProvider.m
+++ b/client/src/cordova/apple/OutlineLib/VpnExtension/Sources/PacketTunnelProvider.m
@@ -37,6 +37,14 @@ NSString *const kDefaultPathKey = @"defaultPath";
 @property (nonatomic, nullable) NSString *tunnelId;
 @property (nonatomic, nullable) NSString *transportConfig;
 @property (nonatomic) dispatch_queue_t packetQueue;
+// Device replacement, packet writes and prepared-switch state belong to packetQueue.
+@property (nonatomic) BOOL stopping;
+@property (nonatomic) NSUInteger sessionGeneration;
+@property (nonatomic, nullable) NSString *preparedToken;
+@property (nonatomic, nullable) NSString *preparedId;
+@property (nonatomic, nullable) NSString *preparedTransport;
+@property (nonatomic, nullable) OutlineClient *preparedClient;
+@property (nonatomic, nullable) NSString *committedToken;
 @end
 
 @implementation PacketTunnelProvider
@@ -60,6 +68,16 @@ NSString *const kDefaultPathKey = @"defaultPath";
 
 - (void)startTunnelWithOptions:(NSDictionary *)options
              completionHandler:(void (^)(NSError *))completion {
+  dispatch_async(self.packetQueue, ^{
+    self.stopping = NO;
+    self.sessionGeneration++;
+    self.committedToken = nil;
+    [self startTunnelOnPacketQueueWithOptions:options completionHandler:completion];
+  });
+}
+
+- (void)startTunnelOnPacketQueueWithOptions:(NSDictionary *)options
+                        completionHandler:(void (^)(NSError *))completion {
   DDLogInfo(@"Starting tunnel");
   DDLogDebug(@"Options are %@", options);
 
@@ -75,13 +93,21 @@ NSString *const kDefaultPathKey = @"defaultPath";
     return startDone([SwiftBridge newInvalidConfigOutlineErrorWithMessage:@"no config specified"]);
   }
   NETunnelProviderProtocol *protocol = (NETunnelProviderProtocol *)self.protocolConfiguration;
-  NSString *tunnelId = protocol.providerConfiguration[@"id"];
+  NSDictionary *configuration = protocol.providerConfiguration;
+  NSDictionary *pending = configuration[@"pendingSwitch"];
+  if ([pending isKindOfClass:[NSDictionary class]] &&
+      [pending[@"token"] isKindOfClass:[NSString class]] &&
+      [pending[@"token"] isEqual:[SwiftBridge lastCommittedSwitchToken]]) {
+    configuration = pending;
+    self.committedToken = pending[@"token"];
+  }
+  NSString *tunnelId = configuration[@"id"];
   if (![tunnelId isKindOfClass:[NSString class]]) {
     DDLogError(@"Failed to retrieve the tunnel id.");
     return startDone([SwiftBridge newInternalOutlineErrorWithMessage:@"no tunnal ID specified"]);
   }
 
-  NSString *transportConfig = protocol.providerConfiguration[@"transport"];
+  NSString *transportConfig = configuration[@"transport"];
   if (![transportConfig isKindOfClass:[NSString class]]) {
     DDLogError(@"Failed to retrieve the transport configuration.");
     return startDone([SwiftBridge newInvalidConfigOutlineErrorWithMessage:@"config is not a String"]);
@@ -108,8 +134,12 @@ NSString *const kDefaultPathKey = @"defaultPath";
     return startDone([SwiftBridge newOutlineErrorFromPlatformError:deviceErr]);
   }
 
+  NSUInteger generation = self.sessionGeneration;
   [self startRouting:[SwiftBridge getTunnelNetworkSettings]
           completion:^(NSError *_Nullable error) {
+            if (self.stopping || self.sessionGeneration != generation) {
+              return startDone([SwiftBridge newInternalOutlineErrorWithMessage:@"VPN start cancelled"]);
+            }
             if (error != nil) {
               return startDone([SwiftBridge newOutlineErrorFromNsError:error]);
             }
@@ -124,30 +154,39 @@ NSString *const kDefaultPathKey = @"defaultPath";
 
 - (void)stopTunnelWithReason:(NEProviderStopReason)reason
            completionHandler:(void (^)(void))completionHandler {
-  DDLogInfo(@"Stopping tunnel, reason: %ld", (long)reason);
-  [self stopListeningForNetworkChanges];
-  PlaterrorsPlatformError *err = [self.remoteDevice close];
-  if (err != nil) {
-    DDLogWarn(@"Failed to close remote device: %@", err.error);
-  }
-  completionHandler();
+  dispatch_async(self.packetQueue, ^{
+    DDLogInfo(@"Stopping tunnel, reason: %ld", (long)reason);
+    self.stopping = YES;
+    self.sessionGeneration++;
+    [self discardPreparedSwitch];
+    [self stopListeningForNetworkChanges];
+    PlaterrorsPlatformError *err = [self.remoteDevice close];
+    self.remoteDevice = nil;
+    if (err != nil) {
+      DDLogWarn(@"Failed to close remote device: %@", err.error);
+    }
+    completionHandler();
+  });
 }
 
 # pragma mark - Network
 
 - (void)startRouting:(NEPacketTunnelNetworkSettings *)settings
            completion:(void (^)(NSError *))completionHandler {
-  __weak PacketTunnelProvider *weakSelf = self;
+  NSUInteger generation = self.sessionGeneration;
+  __weak typeof(self) weakSelf = self;
   [self setTunnelNetworkSettings:settings completionHandler:^(NSError * _Nullable error) {
-    if (error != nil) {
-      DDLogError(@"Failed to start routing: %@", error.localizedDescription);
-    } else {
-      DDLogInfo(@"Routing started");
-      // Passing nil settings clears the tunnel network configuration. Indicate to the system that
-      // the tunnel is being re-established if this is the case.
-      weakSelf.reasserting = settings == nil;
+    typeof(self) strongSelf = weakSelf;
+    if (strongSelf == nil) {
+      return completionHandler(error);
     }
-    completionHandler(error);
+    dispatch_async(strongSelf.packetQueue, ^{
+      if (!strongSelf.stopping && strongSelf.sessionGeneration == generation && error == nil) {
+        DDLogInfo(@"Routing started");
+        strongSelf.reasserting = strongSelf.remoteDevice == nil;
+      }
+      completionHandler(error);
+    });
   }];
 }
 
@@ -186,26 +225,23 @@ NSString *const kDefaultPathKey = @"defaultPath";
     return;
   }
 
-  dispatch_async(dispatch_get_main_queue(), ^{
+  dispatch_async(self.packetQueue, ^{
     [self handleNetworkChange:self.defaultPath];
   });
 }
 
 - (void)handleNetworkChange:(NWPath *)newDefaultPath {
+  if (self.stopping) {
+    return;
+  }
   DDLogInfo(@"Network connectivity changed");
   if (newDefaultPath.status == NWPathStatusSatisfied) {
-    DDLogInfo(@"Reconnecting tunnel.");
     [self.remoteDevice notifyNetworkChanged];
     [self reconnectTunnel];
   } else {
-    DDLogInfo(@"Clearing tunnel settings.");
-    [self startRouting:nil completion:^(NSError * _Nullable error) {
-      if (error != nil) {
-        DDLogError(@"Failed to clear tunnel network settings: %@", error.localizedDescription);
-      } else {
-        DDLogInfo(@"Tunnel settings cleared");
-      }
-    }];
+    // Keep routes and DNS installed while offline. Clearing them opens a direct
+    // network window when the underlying network returns.
+    self.reasserting = YES;
   }
 }
 
@@ -244,7 +280,9 @@ bool getIpAddressString(const struct sockaddr *sa, char *s, socklen_t maxbytes) 
   [self startRouting:[SwiftBridge getTunnelNetworkSettings]
          completion:^(NSError *_Nullable error) {
            if (error != nil) {
-             [self cancelTunnelWithError:error];
+             // A routing refresh failure must not tear down the protected session.
+             self.reasserting = YES;
+             DDLogError(@"Failed to refresh tunnel settings: %@", error.localizedDescription);
            }
          }];
 }
@@ -261,15 +299,26 @@ bool getIpAddressString(const struct sockaddr *sa, char *s, socklen_t maxbytes) 
 
 // Writes packets from the VPN to the tunnel.
 - (void)processPackets {
+  if (self.stopping) {
+    return;
+  }
   __weak typeof(self) weakSelf = self;
-  __block long bytesWritten = 0;
-  [weakSelf.packetFlow readPacketsWithCompletionHandler:^(NSArray<NSData *> *_Nonnull packets,
-                                                          NSArray<NSNumber *> *_Nonnull protocols) {
-    for (NSData *packet in packets) {
-      [weakSelf.remoteDevice write:packet ret0_:&bytesWritten error:nil];
+  [self.packetFlow readPacketsWithCompletionHandler:^(NSArray<NSData *> *packets,
+                                                      NSArray<NSNumber *> *protocols) {
+    typeof(self) strongSelf = weakSelf;
+    if (strongSelf == nil) {
+      return;
     }
-    dispatch_async(weakSelf.packetQueue, ^{
-      [weakSelf processPackets];
+    dispatch_async(strongSelf.packetQueue, ^{
+      if (strongSelf.stopping) {
+        return;
+      }
+      long bytesWritten = 0;
+      for (NSData *packet in packets) {
+        // A missing device intentionally drops packets; routes still point to TUN.
+        [strongSelf.remoteDevice write:packet ret0_:&bytesWritten error:nil];
+      }
+      [strongSelf processPackets];
     });
   }];
 }
@@ -329,14 +378,131 @@ bool getIpAddressString(const struct sockaddr *sa, char *s, socklen_t maxbytes) 
 
 NSString *const kFetchLastErrorIPCName = @"fetchLastDisconnectDetailedJsonError";
 
+// Versioned handover IPC. Never log the request: it contains access credentials.
 - (void)handleAppMessage:(NSData *)messageData completionHandler:(void (^)(NSData * _Nullable))completion {
-  // mimics fetchLastDisconnectErrorWithCompletionHandler on older systems
+  if (completion == nil) {
+    return;
+  }
   NSString *ipcName = [[NSString alloc] initWithData:messageData encoding:NSUTF8StringEncoding];
-  if (![ipcName isEqualToString:kFetchLastErrorIPCName]) {
-    DDLogWarn(@"Invalid Extension IPC call: %@", ipcName);
+  if ([ipcName isEqualToString:kFetchLastErrorIPCName]) {
+    return completion([SwiftBridge loadLastErrorToIPCResponse]);
+  }
+  id request = [NSJSONSerialization JSONObjectWithData:messageData options:0 error:nil];
+  if (![request isKindOfClass:[NSDictionary class]]) {
     return completion(nil);
   }
-  completion([SwiftBridge loadLastErrorToIPCResponse]);
+  dispatch_async(self.packetQueue, ^{
+    NSString *action = request[@"action"];
+    if ([action isEqual:@"getTunnelId.v1"]) {
+      return completion([SwiftBridge switchResponseWithId:self.tunnelId token:self.committedToken error:nil]);
+    }
+    if ([action isEqual:@"abortSwitch.v1"]) {
+      if ([self.preparedToken isEqual:request[@"token"]]) {
+        [self discardPreparedSwitch];
+      }
+      return completion([SwiftBridge switchResponseWithId:self.tunnelId token:nil error:nil]);
+    }
+    if ([action isEqual:@"prepareSwitch.v1"]) {
+      return [self prepareSwitch:request completion:completion];
+    }
+    if ([action isEqual:@"commitSwitch.v1"]) {
+      return [self commitSwitch:request completion:completion];
+    }
+    completion(nil);
+  });
+}
+
+- (void)discardPreparedSwitch {
+  self.preparedToken = nil;
+  self.preparedId = nil;
+  self.preparedTransport = nil;
+  self.preparedClient = nil;
+}
+
+- (void)prepareSwitch:(NSDictionary *)request completion:(void (^)(NSData *))completion {
+  NSString *token = request[@"token"];
+  NSString *tunnelId = request[@"id"];
+  NSString *transport = request[@"transport"];
+  if (self.stopping || self.tunnelId == nil || self.preparedToken != nil ||
+      ![token isKindOfClass:[NSString class]] || token.length == 0 ||
+      ![tunnelId isKindOfClass:[NSString class]] || tunnelId.length == 0 ||
+      ![transport isKindOfClass:[NSString class]] ||
+      ![self.tunnelId isEqual:request[@"expectedId"]]) {
+    return completion([SwiftBridge switchResponseWithId:self.tunnelId token:nil
+        error:[SwiftBridge newInternalOutlineErrorWithMessage:@"VPN switch is unavailable or stale"]]);
+  }
+  self.preparedToken = token;
+  NSUInteger generation = self.sessionGeneration;
+  // Expire abandoned preparations even if the app exits or loses its IPC reply.
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 60 * NSEC_PER_SEC), self.packetQueue, ^{
+    if ([self.preparedToken isEqual:token]) {
+      [self discardPreparedSwitch];
+    }
+  });
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    OutlineNewClientResult *candidate = [SwiftBridge newClientWithId:tunnelId transportConfig:transport];
+    PlaterrorsPlatformError *error = candidate.error;
+    if (error == nil) {
+      error = Tun2socksCheckClientConnectivity(candidate.client);
+    }
+    dispatch_async(self.packetQueue, ^{
+      if (self.stopping || self.sessionGeneration != generation || ![self.preparedToken isEqual:token]) {
+        return completion([SwiftBridge switchResponseWithId:self.tunnelId token:nil
+            error:[SwiftBridge newInternalOutlineErrorWithMessage:@"VPN switch cancelled"]]);
+      }
+      if (error != nil) {
+        [self discardPreparedSwitch];
+        return completion([SwiftBridge switchResponseWithId:self.tunnelId token:nil
+            error:[SwiftBridge newOutlineErrorFromPlatformError:error]]);
+      }
+      self.preparedClient = candidate.client;
+      self.preparedId = tunnelId;
+      self.preparedTransport = transport;
+      completion([SwiftBridge switchResponseWithId:self.tunnelId token:token error:nil]);
+    });
+  });
+}
+
+- (void)commitSwitch:(NSDictionary *)request completion:(void (^)(NSData *))completion {
+  if (self.stopping || self.preparedClient == nil || ![self.preparedToken isEqual:request[@"token"]]) {
+    return completion([SwiftBridge switchResponseWithId:self.tunnelId token:nil
+        error:[SwiftBridge newInternalOutlineErrorWithMessage:@"VPN switch preparation expired"]]);
+  }
+  OutlineClient *client = self.preparedClient;
+  NSString *tunnelId = self.preparedId;
+  NSString *transport = self.preparedTransport;
+  [self discardPreparedSwitch];
+
+  // lwIP is a singleton. Replace it only after preflight, on the same queue as
+  // packet writes. The system VPN, routes, DNS and packetFlow reader stay alive.
+  [self.remoteDevice close];
+  self.remoteDevice = nil;
+  Tun2socksConnectRemoteDeviceResult *result = Tun2socksConnectRemoteDevice(client);
+  PlaterrorsPlatformError *error = result.error;
+  if (error == nil) {
+    self.remoteDevice = result.device;
+    error = [self relayTraffic:YES];
+  }
+  if (error != nil) {
+    [self.remoteDevice close];
+    self.remoteDevice = nil;
+    self.reasserting = YES;
+    // Preserve the previous logical ID so the app can still Disconnect or retry.
+    return completion([SwiftBridge switchResponseWithId:self.tunnelId token:nil
+        error:[SwiftBridge newOutlineErrorFromPlatformError:error]]);
+  }
+  NSError *persistenceError = [SwiftBridge recordCommittedSwitchWithToken:request[@"token"]];
+  if (persistenceError != nil) {
+    [self.remoteDevice close];
+    self.remoteDevice = nil;
+    self.reasserting = YES;
+    return completion([SwiftBridge switchResponseWithId:self.tunnelId token:nil error:persistenceError]);
+  }
+  self.tunnelId = tunnelId;
+  self.transportConfig = transport;
+  self.committedToken = request[@"token"];
+  self.reasserting = self.defaultPath.status != NWPathStatusSatisfied;
+  completion([SwiftBridge switchResponseWithId:self.tunnelId token:self.committedToken error:nil]);
 }
 
 - (void)cancelTunnelWithError:(nullable NSError *)error {

--- a/client/src/cordova/apple/OutlineLib/VpnExtension/Sources/PacketTunnelProvider.swift
+++ b/client/src/cordova/apple/OutlineLib/VpnExtension/Sources/PacketTunnelProvider.swift
@@ -106,6 +106,42 @@ public class SwiftBridge: NSObject {
   public static func loadLastErrorToIPCResponse() -> NSData? {
     return loadLastDisconnectErrorDetailsToIPCResponse() as? NSData
   }
+
+  // Keep the response keys aligned with SwitchResponse in OutlineVpn.swift.
+  public static func switchResponse(id: String?, token: String?, error: NSError?) -> Data {
+    var response = [String: String]()
+    response["id"] = id
+    response["token"] = token
+    if let error = error {
+      response["errorCode"] = toOutlineError(error: error).code
+      response["errorJson"] = marshalErrorJson(error: error)
+    }
+    // All values are strings, so the dictionary is always JSON-serializable.
+    return try! JSONSerialization.data(withJSONObject: response)
+  }
+
+  // Persist only the transaction UUID, never access credentials. The pending
+  // configuration remains in the system VPN preferences. A restart uses it only
+  // if this marker was written after a successful device replacement.
+  private static func switchMarkerURL() throws -> URL {
+    let directory = try FileManager.default.url(for: .applicationSupportDirectory,
+                                                in: .userDomainMask, appropriateFor: nil, create: true)
+    return directory.appendingPathComponent("committed-vpn-switch")
+  }
+
+  public static func lastCommittedSwitchToken() -> String? {
+    guard let url = try? switchMarkerURL() else { return nil }
+    return try? String(contentsOf: url, encoding: .utf8)
+  }
+
+  public static func recordCommittedSwitch(token: String) -> NSError? {
+    do {
+      try Data(token.utf8).write(to: switchMarkerURL(), options: .atomic)
+      return nil
+    } catch {
+      return newInternalOutlineError(message: "failed to persist VPN switch commit")
+    }
+  }
 }
 
 // Represents an IP subnetwork.

--- a/client/src/cordova/apple/OutlineLib/VpnExtension/Sources/PacketTunnelProvider.swift
+++ b/client/src/cordova/apple/OutlineLib/VpnExtension/Sources/PacketTunnelProvider.swift
@@ -155,7 +155,7 @@ class Subnet: NSObject {
       NSLog("Malformed CIDR subnet")
       return nil
     }
-    guard let prefix = UInt16(components[1]) else {
+    guard let prefix = UInt16(components[1]), prefix <= 32 else {
       NSLog("Invalid subnet prefix")
       return nil
     }
@@ -199,8 +199,8 @@ func getNetworkInterfaceAddresses() -> [String] {
   var interface = interfaces
   while interface != nil {
     // Only consider IPv4 interfaces.
-    if interface!.pointee.ifa_addr.pointee.sa_family == UInt8(AF_INET) {
-      let addr = interface!.pointee.ifa_addr!.withMemoryRebound(to: sockaddr_in.self, capacity: 1) {
+    if let address = interface!.pointee.ifa_addr, address.pointee.sa_family == UInt8(AF_INET) {
+      let addr = address.withMemoryRebound(to: sockaddr_in.self, capacity: 1) {
         $0.pointee.sin_addr
       }
       if let ip = String(cString: inet_ntoa(addr), encoding: .utf8) {

--- a/docs/apple-vpn-handover.md
+++ b/docs/apple-vpn-handover.md
@@ -37,6 +37,12 @@ Network loss now marks the provider as reasserting without clearing its routes
 or DNS. A failed routing refresh does not deliberately cancel the VPN. Private
 network exclusions, including the Tailscale address range, are unchanged.
 
+Packet readers and routing completions belong to a session generation. A fresh
+start replaces its reader; callbacks from a stopped or replaced session cannot
+write packets, re-arm reading, or update the new session's connection status.
+Disconnect-error lookups, including legacy IPC, use the same bounded,
+exactly-once completion helper as handover messages.
+
 ## Scope and limitations
 
 - This is an Apple client implementation, not a Windows/Linux/Android change.
@@ -59,6 +65,9 @@ the repository; no test/spec files were added or modified.
   IPC, missing replies, same-ID refresh, expired/replayed tokens, delayed
   preparation after stop, network loss, commit-marker failure, and restart
   selection before and after commit.
+- Follow-up probes passed for stale/stopped packet readers, delayed routing
+  completion during network loss, native/legacy disconnect-error timeouts,
+  duplicate callbacks, and invalid IPv4 subnet prefixes.
 - A real Go/lwIP probe reproduced destruction of the active singleton when a
   second device is created before its health is known. Ten failed/successful
   client-only preflight cycles kept the existing device usable under `-race`,

--- a/docs/apple-vpn-handover.md
+++ b/docs/apple-vpn-handover.md
@@ -1,0 +1,85 @@
+# Apple VPN server handover
+
+## Behavior
+
+Connecting to another server keeps the existing system VPN interface, routes,
+and DNS configuration installed. The app uses versioned provider messages
+instead of stopping and restarting `NETunnelProviderSession`.
+
+1. Prepare the replacement client and check TCP connectivity while the current
+   server continues carrying traffic. Do not create another remote device here:
+   the SDK's lwIP device is a singleton, and configuring another closes the old one.
+2. Save a pending configuration alongside the current configuration in the system
+   VPN preferences, without changing on-demand rules.
+3. Commit the prepared client on the packet queue. Close the old packet engine,
+   create its replacement, and attach a new return-traffic relay. Keep exactly
+   one packetFlow reader and serialize its writes with replacement and shutdown.
+4. Write an atomic commit marker containing only the transaction UUID. The
+   extension uses a pending configuration after restart only when its token
+   matches this marker. Finalize the preferences and emit logical server-change
+   events; these do not represent a system VPN disconnect.
+
+An unreachable or invalid replacement fails before changing the packet engine.
+A failure after replacement retains routes, drops traffic, and marks the old
+logical server as reconnecting so the user can retry or disconnect. An expired,
+unsupported, or failed IPC request never falls back to stop/start. A lost commit
+reply is reconciled using both runtime server ID and transaction token, including
+when refreshing a configuration for the same server ID.
+
+Explicit Disconnect still tears down the system VPN. It cancels pending starts,
+including a switch whose runtime identity has already changed. Complete app
+operations are serialized across asynchronous waits. Failure to read VPN
+preferences does not get interpreted as an absent VPN. Older extensions retain
+status notifications, but cannot perform this protected handover until restarted
+with the updated extension.
+
+Network loss now marks the provider as reasserting without clearing its routes
+or DNS. A failed routing refresh does not deliberately cancel the VPN. Private
+network exclusions, including the Tailscale address range, are unchanged.
+
+## Scope and limitations
+
+- This is an Apple client implementation, not a Windows/Linux/Android change.
+- Existing TCP sessions may need to reconnect when the remote server changes.
+  There is no promise of instant migration or a zero-millisecond interruption.
+- Preflight checks TCP connectivity, not every destination or UDP service.
+- This is not a general kill switch. Existing route exclusions and IPv4-only
+  configuration are unchanged. Explicit network bindings, other VPNs, OS behavior,
+  extension crashes, and termination can have separate effects.
+- IPC waits are bounded; OS preference operations and transport teardown can
+  have additional waits. Disconnect can wait for an in-flight operation to settle.
+
+## Verification and release gate
+
+Focused verification uses the actual source with controlled adapters, outside
+the repository; no test/spec files were added or modified.
+
+- 100 app handovers and 100 provider handovers passed, with checks for explicit
+  disconnect, rapid switches, failed preparation/commit/preferences, unsupported
+  IPC, missing replies, same-ID refresh, expired/replayed tokens, delayed
+  preparation after stop, network loss, commit-marker failure, and restart
+  selection before and after commit.
+- A real Go/lwIP probe reproduced destruction of the active singleton when a
+  second device is created before its health is known. Ten failed/successful
+  client-only preflight cycles kept the existing device usable under `-race`,
+  with controlled in-memory transports and no external network requests.
+- Existing Go connectivity tests passed with `-race`; VPN and tun2socks packages
+  compiled. Targeted `go vet` passed.
+- The arm64 Mac Catalyst Go framework built. Changed Swift and Objective-C
+  sources compiled against the Catalyst SDK and generated bindings with a
+  logging adapter. This is not a complete signed application build.
+
+Before merging or releasing, build the complete Apple application and validate a
+signed extension with on-device packet capture. The full local Xcode attempt
+could not complete: the generated Cordova host project was absent and package
+resolution remained unfinished. No running VPN or installed app was modified.
+
+Before release, capture TCP, UDP, and DNS on the physical interface during
+successful and failed server switches, same-ID refresh, network loss/recovery,
+rapid connect/disconnect, and app/provider termination. Verify explicit
+Disconnect restores ordinary networking and intentional private-network
+exceptions still work. Check both macOS and iOS, including supported older OS
+versions and upgrades with an already-running older extension.
+
+References: [Apple packet tunnel routing](https://developer.apple.com/documentation/networkextension/nepackettunnelprovider),
+[Apple reasserting state](https://developer.apple.com/documentation/networkextension/netunnelprovider/reasserting).


### PR DESCRIPTION
## Why

Selecting another server currently stops and restarts the system VPN, creating an ordinary-network interval. Preparing another lwIP device early is also unsafe because the SDK's device is a singleton.

## Changes

- Keep the system VPN interface, DNS, and routes installed during server changes. Use versioned prepare/commit IPC instead of stop/start.
- Preflight a replacement client without creating another lwIP device. Keep the current engine on preparation failure; retain routes and drop traffic if engine replacement fails.
- Serialize engine replacement, packet writes, and complete app operations. Keep one packet reader; cancel pending starts on explicit Disconnect, including when commit acknowledgement is pending.
- Bound status/IPC waits, install status observers before actions, and settle continuations once. Reconcile lost replies with both runtime server ID and transaction token.
- Persist pending configuration plus an atomic credential-free commit marker so restart chooses the configuration matching the completed commit.
- Retain routes during network loss and routing-refresh failures. Preserve existing private-network exclusions.
- Include the design, failure behavior, scope, and release checklist in `docs/apple-vpn-handover.md`.

## Verification

- After splitting, the relevant existing Go suites passed again with `-race` and targeted `go vet` on this isolated branch; live external connectivity tests were excluded.

- Actual Swift app source with controlled NetworkExtension adapters passed 100 handovers per run in three final runs; actual provider source passed 100 handovers. Cases included explicit disconnect, rapid switching, failed preparation/commit/preferences, unsupported IPC, missing replies, same-ID refresh, expired/replayed tokens, delayed preparation after stop, network loss, commit-marker failures, and interrupted persistence.
- The old stop/start behavior and the singleton-device destruction hazard were reproduced. Ten failed/successful client-only preflight cycles kept the active actual Go/lwIP device usable under `-race`, using in-memory transports.
- Existing Go connectivity specs passed with `-race`; VPN/tun2socks packages compiled and targeted vet passed.
- Built the arm64 Mac Catalyst Go framework. Changed Swift/Objective-C sources compiled against the Catalyst SDK and generated bindings with warnings as errors and a logging adapter.
- Patch isolation and `git diff --check` passed. Recombining all focused patches reproduces the reviewed source changes exactly.
- No test/spec files were added or modified; controlled probe drivers are kept outside the repository.

## Compatibility and remaining validation

- **Before merge/release: complete a signed app build and live physical-interface packet captures on macOS and iOS. This is an open PR for review, not a verified leak-free release.**
- The full local Xcode build could not complete because the generated Cordova host project was absent and dependency resolution remained unfinished.
- Not a general kill switch: existing route exclusions and IPv4-only configuration remain unchanged. Other VPNs, explicit network bindings, OS behavior, extension crashes, and termination require separate validation.
- Existing TCP sessions may reconnect; no instant or zero-interruption migration is promised. Preflight checks TCP, not every destination or UDP service.
- Older running extensions do not support protected handover: fail without stopping the current VPN until the extension is restarted. Test that upgrade path, failed switching, explicit Disconnect, and private-network access.
- Apple status-waiter fixes are intentionally included because this feature builds on the same connection lifecycle. This PR is independent of the separate shared-Go cancellation PR.

Full npm installation/build checks remain incomplete: npm 12 rejected existing lockfile Git dependencies (`EALLOWGIT`). Isolated registry-only tooling was used without disabling that safeguard.

## Scope

This is one focused part of the reliability review, based directly on upstream `master`; it does not include the other review patches. No installed client, live VPN/DNS setting, or production service was changed by this patch.

## Second review — 2026-08-27

Scope packet-reader and reconnect callbacks to their session generation. Fresh starts replace the reader and clean up failed devices; late routing success cannot erase a network-loss state. Reuse a generic exactly-once deadline helper for handover messages and native/legacy disconnect-error lookups. Remove the unused Action enum, reject IPv4 prefixes above 32, and guard nullable interface addresses. Update the design/release checklist.

Current-source adapters passed 100 app and 100 provider handovers, plus stale/stopped readers, late routing completions, native/legacy error deadlines, duplicate nil callbacks, and subnet boundaries. Ten real Go/lwIP preflight cycles passed under -race. Swift and Objective-C checks passed against the Catalyst SDK and real generated Go bindings with warnings as errors (logging adapter only). This is still NOT a complete signed app build or live packet-leak verification; the existing before-merge/release gate remains.

All touched files and nearby callers were reviewed again. Each focused patch was also checked in combination with the other seven patches for this repository. External probe drivers remain outside the repositories; no test/spec files were added or modified. Existing full-build and platform-validation limitations above still apply.
